### PR TITLE
feat(new source): add postgresql_cdc source and replication slot metrics

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -512,6 +512,7 @@ timeseries
 timespan
 timestamped
 Tizen
+TOAST'd
 TLDs
 Tmobile
 tobz

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -7,6 +7,7 @@ amz
 amzn
 anchore
 andy
+antipattern
 apievent
 apipodspec
 apk
@@ -73,18 +74,21 @@ buffereventsdropped
 buffereventsreceived
 buffereventssent
 bufferpin
+BYPASSRLS
 bvalue
 bwsnrn
 bytesize
 califrag
 califragilistic
 CAROOT
+cdc
 cddl
 cdylib
 cef
 centiseconds
 cernan
 CFFI
+CREATEROLE
 CGP
 cgroups
 chartmuseum
@@ -295,6 +299,7 @@ jsonify
 jsonlines
 jszwedko
 kebabcase
+keepalives
 kernelmode
 keyclock
 keyxxxxx
@@ -311,9 +316,11 @@ landingpad
 leebenson
 leveldb
 libcrypto
+libpq
 librdkafka
 libvector
 lld
+lsn
 loadbalancer
 logdna
 logevents
@@ -329,6 +336,7 @@ lpush
 lucperkins
 lukesteensen
 lvl
+macaddr
 maj
 majorly
 makecache
@@ -406,6 +414,7 @@ nsecs
 ntoa
 ntp
 nullishness
+NULs
 NUMA
 numbackends
 NXRR
@@ -434,10 +443,13 @@ pascalcase
 PEMS
 percpu
 pgo
+pgoutput
+pgwire
 PIDs
 PII
 plainify
 plds
+RLS
 ple
 podspec
 Ponge
@@ -588,6 +600,7 @@ threatmanager
 Throughputs
 Tiltfile
 timberio
+timestamptz
 TIMESTAMPTZ
 TKEY
 tlh
@@ -645,6 +658,8 @@ vrl
 vsize
 vts
 Wakely
+wal
+walsender
 waninfo
 wasmtime
 watchexec
@@ -668,6 +683,7 @@ wtime
 wtimeout
 WTS
 xact
+xid
 xlarge
 xxs
 YAMLs

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -128,6 +128,8 @@ on:
         value: ${{ jobs.int_tests.outputs.opentelemetry }}
       postgres:
         value: ${{ jobs.int_tests.outputs.postgres }}
+      postgresql_cdc:
+        value: ${{ jobs.int_tests.outputs.postgresql_cdc }}
       prometheus:
         value: ${{ jobs.int_tests.outputs.prometheus }}
       pulsar:
@@ -339,6 +341,7 @@ jobs:
       nginx: ${{ steps.filter.outputs.nginx }}
       opentelemetry: ${{ steps.filter.outputs.opentelemetry }}
       postgres: ${{ steps.filter.outputs.postgres }}
+      postgresql_cdc: ${{ steps.filter.outputs.postgresql_cdc }}
       prometheus: ${{ steps.filter.outputs.prometheus }}
       pulsar: ${{ steps.filter.outputs.pulsar }}
       redis: ${{ steps.filter.outputs.redis }}
@@ -405,6 +408,7 @@ jobs:
             "nginx": ${{ steps.filter.outputs.nginx }},
             "opentelemetry": ${{ steps.filter.outputs.opentelemetry }},
             "postgres": ${{ steps.filter.outputs.postgres }},
+            "postgresql_cdc": ${{ steps.filter.outputs.postgresql_cdc }},
             "prometheus": ${{ steps.filter.outputs.prometheus }},
             "pulsar": ${{ steps.filter.outputs.pulsar }},
             "redis": ${{ steps.filter.outputs.redis }},

--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -136,6 +136,7 @@ jobs:
             "nginx",
             "opentelemetry",
             "postgres",
+            "postgresql_cdc",
             "prometheus",
             "pulsar",
             "redis",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,6 +130,7 @@ jobs:
             "nginx",
             "opentelemetry",
             "postgres",
+            "postgresql_cdc",
             "prometheus",
             "pulsar",
             "redis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8241,6 +8241,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgwire-replication"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec6334b2466a0163bd91c29e06a25b391c155231934aee80381b99560e240e"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "hmac",
+ "rand 0.9.4",
+ "sha2",
+ "thiserror 1.0.68",
+ "tokio",
+ "tokio-util",
+ "tracing 0.1.44",
+]
+
+[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13136,6 +13154,7 @@ dependencies = [
  "parquet",
  "pastey",
  "percent-encoding",
+ "pgwire-replication",
  "pin-project",
  "postgres-openssl",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,6 +442,7 @@ stream-cancel = { version = "0.8.2", default-features = false }
 strip-ansi-escapes = { version = "0.2.1", default-features = false }
 syslog = { version = "6.1.1", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.13", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
+pgwire-replication = { version = "0.3.2", default-features = false, features = ["scram"], optional = true }
 tokio-tungstenite = { workspace = true, features = ["connect"], optional = true }
 toml.workspace = true
 hickory-proto = { workspace = true, optional = true }
@@ -685,6 +686,7 @@ sources-logs = [
   "sources-nats",
   "sources-okta",
   "sources-opentelemetry",
+  "sources-postgresql_cdc",
   "sources-pulsar",
   "sources-file_descriptor",
   "sources-redis",
@@ -756,6 +758,7 @@ sources-opentelemetry = [
   "sources-utils-http-headers",
   "sources-vector",
 ]
+sources-postgresql_cdc = ["dep:postgres-openssl", "dep:pgwire-replication", "dep:tokio-postgres"]
 sources-postgresql_metrics = ["dep:postgres-openssl", "dep:tokio-postgres"]
 sources-prometheus = ["sources-prometheus-scrape", "sources-prometheus-remote-write", "sources-prometheus-pushgateway"]
 sources-prometheus-scrape = ["sinks-prometheus", "sources-utils-http-client", "vector-lib/prometheus"]
@@ -1006,6 +1009,7 @@ all-integration-tests = [
   "nats-integration-tests",
   "nginx-integration-tests",
   "opentelemetry-integration-tests",
+  "postgresql_cdc-integration-tests",
   "postgresql_metrics-integration-tests",
   "postgres_sink-integration-tests",
   "prometheus-integration-tests",
@@ -1076,6 +1080,8 @@ mqtt-integration-tests = ["sinks-mqtt", "sources-mqtt"]
 nats-integration-tests = ["sinks-nats", "sources-nats"]
 nginx-integration-tests = ["sources-nginx_metrics"]
 opentelemetry-integration-tests = ["sources-opentelemetry", "dep:prost"]
+postgresql_cdc-integration-tests = ["sources-postgresql_cdc"]
+postgresql_cdc-benchmarks = ["postgresql_cdc-integration-tests"]
 postgresql_metrics-integration-tests = ["sources-postgresql_metrics"]
 postgres_sink-integration-tests = ["sinks-postgres"]
 prometheus-integration-tests = ["sinks-prometheus", "sources-prometheus", "sinks-influxdb"]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -557,6 +557,7 @@ pest,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dra
 pest_derive,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
 pest_generator,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
 pest_meta,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
+pgwire-replication,https://github.com/vnvo/pgwire-replication,Apache-2.0 OR MIT,Vahid Negahdari <vahid.negahdari@gmail.com>
 phf,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 phf_shared,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project Authors

--- a/changelog.d/postgresql_cdc_source.feature.md
+++ b/changelog.d/postgresql_cdc_source.feature.md
@@ -1,0 +1,3 @@
+Add a new `postgresql_cdc` source that streams change-data-capture events from PostgreSQL using logical replication and the built-in `pgoutput` plugin. The source attaches to an existing publication and replication slot, emits INSERT / UPDATE / DELETE / TRUNCATE events with full transaction context, and integrates with Vector's end-to-end acknowledgement system so the slot's `confirmed_flush_lsn` only advances after every event from a committed transaction has been acknowledged downstream.
+
+authors: jmealo

--- a/config/examples/postgresql_cdc.yaml
+++ b/config/examples/postgresql_cdc.yaml
@@ -1,0 +1,34 @@
+# PostgreSQL CDC Example
+# ------------------------------------------------------------------------------
+# Streams logical-replication change events (INSERT / UPDATE / DELETE / TRUNCATE)
+# from a PostgreSQL database into a console sink as JSON. The source attaches
+# to an existing publication and replication slot using PostgreSQL's built-in
+# `pgoutput` plugin.
+#
+# Prerequisites (run on the database, as a superuser or replication-privileged
+# user):
+#
+#   ALTER SYSTEM SET wal_level = logical;
+#   -- restart Postgres for wal_level to take effect
+#
+#   CREATE PUBLICATION vector_pub FOR TABLE orders, customers;
+#   SELECT pg_create_logical_replication_slot('vector_slot', 'pgoutput');
+#
+# Acknowledgements are enabled by default for this source: the slot's
+# `confirmed_flush_lsn` only advances after every event from a transaction has
+# been acknowledged by the downstream sink. This is what makes the source safe
+# to use as the head of a critical-path data pipeline.
+
+sources:
+  postgres_cdc:
+    type: "postgresql_cdc"
+    connection_string: "postgres://vector:vector@127.0.0.1:5432/app"
+    replication_slot: "vector_slot"
+    publication_name: "vector_pub"
+
+sinks:
+  out:
+    inputs: ["postgres_cdc"]
+    type: "console"
+    encoding:
+      codec: "json"

--- a/lib/vector-common/src/byte_size_of.rs
+++ b/lib/vector-common/src/byte_size_of.rs
@@ -161,6 +161,7 @@ num!(i64);
 num!(i128);
 num!(f32);
 num!(f64);
+num!(bool);
 
 impl ByteSizeOf for Box<RawValue> {
     fn allocated_bytes(&self) -> usize {

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -107,6 +107,8 @@ mod open;
     feature = "sinks-datadog_events",
 ))]
 mod parser;
+#[cfg(feature = "sources-postgresql_cdc")]
+mod postgresql_cdc;
 #[cfg(feature = "sources-postgresql_metrics")]
 mod postgresql_metrics;
 mod process;
@@ -256,6 +258,8 @@ pub(crate) use self::nginx_metrics::*;
     feature = "sinks-datadog_events",
 ))]
 pub(crate) use self::parser::*;
+#[cfg(feature = "sources-postgresql_cdc")]
+pub(crate) use self::postgresql_cdc::*;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub(crate) use self::postgresql_metrics::*;
 #[cfg(any(

--- a/src/internal_events/postgresql_cdc.rs
+++ b/src/internal_events/postgresql_cdc.rs
@@ -1,0 +1,114 @@
+use vector_lib::{
+    NamedInternalEvent, counter,
+    internal_event::{CounterName, InternalEvent, error_stage, error_type},
+};
+
+/// Emitted when the pgoutput parser fails to decode an XLogData payload from
+/// the server. Halts the source — log + counter + error_code tag so operators
+/// can correlate to PG-side issues (corrupt WAL, protocol-version skew, etc).
+#[derive(Debug, NamedInternalEvent)]
+pub struct PostgresqlCdcParseError {
+    pub error: String,
+}
+
+impl InternalEvent for PostgresqlCdcParseError {
+    fn emit(self) {
+        error!(
+            message = "Failed to parse pgoutput message; halting source to avoid data loss.",
+            error = %self.error,
+            error_code = "pgoutput_parse",
+            error_type = error_type::PARSER_FAILED,
+            stage = error_stage::PROCESSING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "pgoutput_parse",
+            "error_type" => error_type::PARSER_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}
+
+/// Emitted when the replication stream itself reports an error
+/// (connection drop, server-side error, auth failure, etc).
+#[derive(Debug, NamedInternalEvent)]
+pub struct PostgresqlCdcReplicationError {
+    pub error: String,
+}
+
+impl InternalEvent for PostgresqlCdcReplicationError {
+    fn emit(self) {
+        error!(
+            message = "Replication stream error.",
+            error = %self.error,
+            error_code = "replication_stream",
+            error_type = error_type::READER_FAILED,
+            stage = error_stage::RECEIVING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "replication_stream",
+            "error_type" => error_type::READER_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}
+
+/// Emitted when a sink reports `Errored` or `Rejected` for an LSN's batch
+/// of events. The source halts; topology will restart it from the slot's
+/// last confirmed LSN, so the affected transaction will be re-delivered.
+#[derive(Debug, NamedInternalEvent)]
+pub struct PostgresqlCdcSinkAckFailed {
+    pub lsn: u64,
+    pub status: &'static str,
+}
+
+impl InternalEvent for PostgresqlCdcSinkAckFailed {
+    fn emit(self) {
+        error!(
+            message = "Sink reported failed delivery; stopping replication.",
+            lsn = %self.lsn,
+            status = self.status,
+            error_code = "sink_ack_failed",
+            error_type = error_type::ACKNOWLEDGMENT_FAILED,
+            stage = error_stage::PROCESSING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "sink_ack_failed",
+            "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}
+
+/// Emitted on a protocol-state violation (a row event arrives outside a
+/// transaction, or a transactional logical message arrives outside a txn).
+/// Halts the source. Should never fire in practice; if it does, it indicates
+/// either a Postgres bug or a pgwire-replication regression.
+#[derive(Debug, NamedInternalEvent)]
+pub struct PostgresqlCdcProtocolViolation {
+    pub detail: &'static str,
+}
+
+impl InternalEvent for PostgresqlCdcProtocolViolation {
+    fn emit(self) {
+        error!(
+            message = "pgoutput protocol violation; halting source.",
+            detail = self.detail,
+            error_code = "protocol_violation",
+            error_type = error_type::CONDITION_FAILED,
+            stage = error_stage::PROCESSING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "protocol_violation",
+            "error_type" => error_type::CONDITION_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -68,6 +68,8 @@ pub mod nginx_metrics;
 pub mod okta;
 #[cfg(feature = "sources-opentelemetry")]
 pub mod opentelemetry;
+#[cfg(feature = "sources-postgresql_cdc")]
+pub mod postgresql_cdc;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub mod postgresql_metrics;
 #[cfg(any(

--- a/src/sources/postgresql_cdc/config.rs
+++ b/src/sources/postgresql_cdc/config.rs
@@ -1,0 +1,333 @@
+//! Configuration for the `postgresql_cdc` source.
+
+use std::path::PathBuf;
+
+use vector_lib::{
+    config::{LegacyKey, LogNamespace},
+    configurable::configurable_component,
+    lookup::owned_value_path,
+    sensitive_string::SensitiveString,
+};
+use vrl::value::Kind;
+
+use crate::{
+    config::{SourceAcknowledgementsConfig, SourceConfig, SourceContext, SourceOutput},
+    schema,
+};
+
+/// TLS configuration for the `postgresql_cdc` source.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresqlCdcTlsConfig {
+    /// Absolute path to a PEM-encoded CA certificate file used to verify the
+    /// Postgres server certificate.
+    #[configurable(metadata(docs::examples = "/etc/ssl/certs/ca.pem"))]
+    pub ca_file: PathBuf,
+
+    /// Whether to verify the server hostname against the certificate.
+    ///
+    /// Set to `false` to verify the certificate chain only (equivalent to
+    /// `sslmode=verify-ca`). Default is `true` (`sslmode=verify-full`).
+    #[serde(default = "default_verify_hostname")]
+    pub verify_hostname: bool,
+}
+
+const fn default_verify_hostname() -> bool {
+    true
+}
+
+/// Configuration for the `postgresql_cdc` source.
+///
+/// Streams logical replication events (INSERT / UPDATE / DELETE / TRUNCATE)
+/// from a PostgreSQL database using the built-in `pgoutput` plugin. Requires
+/// an existing logical replication slot and publication that the source can
+/// attach to — the source will not create or drop them.
+#[configurable_component(source(
+    "postgresql_cdc",
+    "Stream change-data-capture events from PostgreSQL using logical replication (pgoutput)."
+))]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresqlCdcConfig {
+    /// libpq-style connection URI for the PostgreSQL server.
+    ///
+    /// Must NOT include replication-specific parameters such as `replication`
+    /// or `database=replication`; the source sets those internally on the
+    /// replication connection.
+    #[configurable(metadata(
+        docs::examples = "postgres://vector:password@db.example.com:5432/app"
+    ))]
+    pub connection_string: SensitiveString,
+
+    /// Name of an existing logical replication slot that uses the `pgoutput`
+    /// output plugin. The slot must be created out-of-band (e.g. via
+    /// `SELECT pg_create_logical_replication_slot('my_slot', 'pgoutput')`) —
+    /// the source will not create or drop it.
+    #[configurable(metadata(docs::examples = "vector_slot"))]
+    pub replication_slot: String,
+
+    /// Name of an existing publication to subscribe to. The publication
+    /// determines which tables and DML operations are replicated.
+    #[configurable(metadata(docs::examples = "vector_pub"))]
+    pub publication_name: String,
+
+    /// Optional LSN to start streaming from, in `X/Y` hex format.
+    ///
+    /// If unset, the source passes `0/0` to `START_REPLICATION`, which
+    /// causes PostgreSQL to resume from the slot's `confirmed_flush_lsn`
+    /// automatically. Override only for advanced replay scenarios.
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = "16/B374D848"))]
+    pub slot_start_lsn: Option<String>,
+
+    /// TLS configuration for the connection. If unset, the source connects
+    /// without TLS.
+    #[serde(default)]
+    #[configurable(derived)]
+    pub tls: Option<PostgresqlCdcTlsConfig>,
+
+    /// End-to-end acknowledgement configuration.
+    ///
+    /// When acknowledgements are enabled (the default for this source) the
+    /// confirmed-flush LSN is only advanced after every downstream sink has
+    /// acknowledged the events produced by the corresponding transaction.
+    #[serde(default)]
+    #[configurable(derived)]
+    pub acknowledgements: SourceAcknowledgementsConfig,
+
+    /// The log namespace to use for events emitted by this source.
+    ///
+    /// When `true`, fields like `operation`, `lsn`, `schema`, `table`,
+    /// `new`, `old`, and the transaction metadata are placed under
+    /// `%postgresql_cdc.<field>` event metadata; when `false`, they are
+    /// placed at the root of the `LogEvent` (the legacy shape). When
+    /// unset, the source inherits the global `log_namespace` setting.
+    #[configurable(metadata(docs::hidden))]
+    #[serde(default)]
+    pub log_namespace: Option<bool>,
+}
+
+impl Default for PostgresqlCdcConfig {
+    fn default() -> Self {
+        Self {
+            connection_string: SensitiveString::default(),
+            replication_slot: "vector_slot".to_owned(),
+            publication_name: "vector_pub".to_owned(),
+            slot_start_lsn: None,
+            tls: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            log_namespace: None,
+        }
+    }
+}
+
+impl_generate_config_from_default!(PostgresqlCdcConfig);
+
+/// Returns `Ok(())` if `name` is a valid PostgreSQL identifier (the same rules
+/// PG itself enforces for unquoted identifiers).
+///
+/// This is a security-critical validation: pgwire-replication's
+/// `START_REPLICATION` command interpolates `replication_slot` without
+/// escaping, so accepting an arbitrary string would let a malicious config
+/// rewrite the replication command. Validating up-front at config load is
+/// strictly preferable to runtime-escaping the value in source.rs, because
+/// configuration errors surface during `vector validate` rather than at
+/// startup.
+fn validate_pg_identifier(name: &str, field: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if name.len() > 63 {
+        return Err(format!(
+            "{field} must be at most 63 characters (PostgreSQL identifier limit)"
+        ));
+    }
+    let mut chars = name.chars();
+    let first = chars
+        .next()
+        .expect("name is non-empty (checked at function entry)");
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(format!(
+            "{field} must start with a letter or underscore (got {first:?})"
+        ));
+    }
+    for c in chars {
+        if !(c.is_ascii_alphanumeric() || c == '_' || c == '$') {
+            return Err(format!(
+                "{field} may only contain ASCII letters, digits, underscores, \
+                 or `$` (got {c:?})"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "postgresql_cdc")]
+impl SourceConfig for PostgresqlCdcConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<super::super::Source> {
+        validate_pg_identifier(&self.replication_slot, "replication_slot")?;
+        validate_pg_identifier(&self.publication_name, "publication_name")?;
+        super::source::build(self.clone(), cx).await
+    }
+
+    fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
+        // Resolve the effective namespace and register every CDC field as
+        // source metadata. Under `Legacy`, each field lands at the root of
+        // the `LogEvent` (the original shape); under `Vector`, each field
+        // lands under `%postgresql_cdc.<field>`. We use the same
+        // registration call for both modes so the schema definition stays
+        // consistent and downstream schema validators know where to find
+        // each field.
+        let log_namespace = global_log_namespace.merge(self.log_namespace);
+        let schema_definition =
+            schema::Definition::default_for_namespace(&[log_namespace].into_iter().collect())
+                .with_standard_vector_source_metadata()
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("operation"))),
+                    &owned_value_path!("operation"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("lsn"))),
+                    &owned_value_path!("lsn"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("schema"))),
+                    &owned_value_path!("schema"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("table"))),
+                    &owned_value_path!("table"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("new"))),
+                    &owned_value_path!("new"),
+                    Kind::object(vrl::value::kind::Collection::any()).or_null(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("old"))),
+                    &owned_value_path!("old"),
+                    Kind::object(vrl::value::kind::Collection::any()).or_null(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("transaction_id"))),
+                    &owned_value_path!("transaction_id"),
+                    Kind::integer().or_null(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!(
+                        "transaction_timestamp"
+                    ))),
+                    &owned_value_path!("transaction_timestamp"),
+                    Kind::timestamp().or_null(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("__toast_omitted"))),
+                    &owned_value_path!("toast_omitted"),
+                    Kind::array(vrl::value::kind::Collection::from_unknown(Kind::bytes())),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("transactional"))),
+                    &owned_value_path!("transactional"),
+                    Kind::boolean(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("prefix"))),
+                    &owned_value_path!("prefix"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_source_metadata(
+                    PostgresqlCdcConfig::NAME,
+                    Some(LegacyKey::Overwrite(owned_value_path!("content"))),
+                    &owned_value_path!("content"),
+                    Kind::bytes(),
+                    None,
+                );
+
+        vec![SourceOutput::new_maybe_logs(
+            vector_lib::config::DataType::Log,
+            schema_definition,
+        )]
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<PostgresqlCdcConfig>();
+    }
+
+    #[test]
+    fn identifier_validation_accepts_normal_names() {
+        for name in [
+            "slot",
+            "Vector_Slot",
+            "slot_1",
+            "slot$ext",
+            "_underscore",
+            "a",             // single letter
+            &"a".repeat(63), // boundary
+        ] {
+            assert!(
+                validate_pg_identifier(name, "slot").is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn identifier_validation_rejects_injection_attempts() {
+        // SQL injection vectors via the unescaped slot identifier.
+        for evil in [
+            "s LOGICAL 0/0 (publication_names 'p')",
+            "s; DROP SLOT",
+            "s'or'1'='1",
+            "s\nLOGICAL",
+            "1starts_with_digit",
+            "",
+            &"a".repeat(64), // over 63
+            "has space",
+            "with-dash",
+            "with.dot",
+        ] {
+            assert!(
+                validate_pg_identifier(evil, "slot").is_err(),
+                "expected {evil:?} to be rejected"
+            );
+        }
+    }
+}

--- a/src/sources/postgresql_cdc/integration_tests.rs
+++ b/src/sources/postgresql_cdc/integration_tests.rs
@@ -1,0 +1,1672 @@
+//! Integration tests for the `postgresql_cdc` source.
+//!
+//! Requires a running PostgreSQL instance with `wal_level=logical`,
+//! `max_replication_slots>=10`, and `max_wal_senders>=10`. The
+//! `tests/integration/postgresql_cdc/config/compose.yaml` file in this
+//! repository provisions a suitable instance. Run via:
+//!
+//! ```sh
+//! cargo vdev int test postgresql_cdc
+//! ```
+
+#![allow(clippy::print_stdout)] // for diagnostic output on failure
+
+use std::time::Duration;
+
+use futures::{Stream, StreamExt};
+use tokio::time;
+use tokio_postgres::{Client, NoTls};
+use vector_lib::{event::Event, sensitive_string::SensitiveString};
+
+use super::config::PostgresqlCdcConfig;
+use crate::{
+    SourceSender,
+    config::{SourceAcknowledgementsConfig, SourceConfig, SourceContext},
+    test_util::{integration::postgres::pg_url, random_string, random_table_name, trace_init},
+};
+
+/// Per-test fixture — table + publication + slot, all with random names so
+/// tests can run in parallel without colliding.
+struct CdcFixture {
+    client: Client,
+    table: String,
+    publication: String,
+    slot: String,
+    endpoint: String,
+}
+
+impl CdcFixture {
+    async fn setup(create_table_sql: &str) -> Self {
+        let endpoint = pg_url();
+        let (client, connection) = tokio_postgres::connect(&endpoint, NoTls)
+            .await
+            .expect("setup: connect to Postgres");
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                tracing::debug!(message = "setup connection error", error = %e);
+            }
+        });
+
+        let suffix = random_string(8).to_lowercase();
+        let table = random_table_name();
+        let publication = format!("vector_pub_{suffix}");
+        let slot = format!("vector_slot_{suffix}");
+
+        let slot_literal = quote_literal(&slot);
+        let publication_ident = quote_ident(&publication);
+        let table_ident = quote_ident(&table);
+
+        // Best-effort: drop any leftover slot/publication from a prior aborted
+        // test run. These statements may fail harmlessly if nothing exists.
+        let _ = client
+            .simple_query(&format!(
+                "SELECT pg_drop_replication_slot({slot_literal}) WHERE EXISTS \
+                 (SELECT 1 FROM pg_replication_slots WHERE slot_name={slot_literal})"
+            ))
+            .await;
+        let _ = client
+            .simple_query(&format!("DROP PUBLICATION IF EXISTS {publication_ident}"))
+            .await;
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {table_ident} CASCADE"))
+            .await;
+
+        let create_sql = create_table_sql.replace("{table}", &table_ident);
+        client
+            .simple_query(&create_sql)
+            .await
+            .expect("create test table");
+        client
+            .simple_query(&format!(
+                "CREATE PUBLICATION {publication_ident} FOR TABLE {table_ident}"
+            ))
+            .await
+            .expect("create publication");
+        client
+            .simple_query(&format!(
+                "SELECT pg_create_logical_replication_slot({slot_literal}, 'pgoutput')"
+            ))
+            .await
+            .expect("create replication slot");
+
+        Self {
+            client,
+            table,
+            publication,
+            slot,
+            endpoint,
+        }
+    }
+
+    /// Adds an extra table to the existing publication. Used by the
+    /// multi-table test case.
+    async fn add_table_to_publication(&self, second_table: &str, create_sql: &str) {
+        self.client
+            .simple_query(&create_sql.replace("{table}", second_table))
+            .await
+            .expect("create second table");
+        self.client
+            .simple_query(&format!(
+                "ALTER PUBLICATION {} ADD TABLE {}",
+                self.publication, second_table
+            ))
+            .await
+            .expect("add table to publication");
+    }
+
+    fn config(&self) -> PostgresqlCdcConfig {
+        PostgresqlCdcConfig {
+            connection_string: SensitiveString::from(self.endpoint.clone()),
+            replication_slot: self.slot.clone(),
+            publication_name: self.publication.clone(),
+            slot_start_lsn: None,
+            tls: None,
+            // Force ack on for integration tests. The default
+            // SourceContext::new_test() has acknowledgements=false, so
+            // without this the source would never attach BatchNotifiers and
+            // confirmed_flush_lsn would never advance.
+            acknowledgements: SourceAcknowledgementsConfig::from(Some(true)),
+            // Integration tests assert on root-placed fields, which is the
+            // `Legacy` shape. Vector-namespace placement is exercised
+            // separately via the parser's unit tests.
+            log_namespace: Some(false),
+        }
+    }
+
+    async fn confirmed_flush_lsn(&self) -> Option<String> {
+        let row = self
+            .client
+            .query_opt(
+                "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name=$1",
+                &[&self.slot],
+            )
+            .await
+            .expect("query confirmed_flush_lsn");
+        row.and_then(|r| r.get(0))
+    }
+
+    /// Polls `confirmed_flush_lsn` until it differs from `baseline` (i.e. has
+    /// advanced), or `timeout` elapses. Polls every 100ms so we don't waste
+    /// up to half a second after the advancement actually happens. Returns
+    /// the new LSN or `None` if it never advanced.
+    async fn wait_for_lsn_to_advance(
+        &self,
+        baseline: Option<String>,
+        timeout: Duration,
+    ) -> Option<String> {
+        let deadline = time::Instant::now() + timeout;
+        loop {
+            time::sleep(Duration::from_millis(100)).await;
+            let now = self.confirmed_flush_lsn().await;
+            if now.is_some() && now != baseline {
+                return now;
+            }
+            if time::Instant::now() >= deadline {
+                return None;
+            }
+        }
+    }
+
+    /// Polls until `confirmed_flush_lsn >= target_lsn` (using Postgres'
+    /// native pg_lsn comparison). This is the right primitive for resume
+    /// tests: we need to know that every event up to a particular LSN is
+    /// durably acknowledged before tearing down the source.
+    async fn wait_for_lsn_at_or_past(&self, target_lsn: &str, timeout: Duration) -> Option<String> {
+        // Defensive: LSN format is `X/Y` hex from our own pgoutput parser.
+        // Reject anything else before interpolating into SQL.
+        assert!(
+            target_lsn
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() || c == '/'),
+            "wait_for_lsn_at_or_past called with non-LSN string: {target_lsn:?}"
+        );
+        let deadline = time::Instant::now() + timeout;
+        loop {
+            time::sleep(Duration::from_millis(100)).await;
+            // tokio-postgres can't bind `&str` as the `pg_lsn` type, so we
+            // interpolate the LSN literal (validated above) directly.
+            let sql = format!(
+                "SELECT confirmed_flush_lsn::text \
+                 FROM pg_replication_slots \
+                 WHERE slot_name = $1 \
+                   AND confirmed_flush_lsn >= '{target_lsn}'::pg_lsn"
+            );
+            let row = self
+                .client
+                .query_opt(&sql, &[&self.slot])
+                .await
+                .expect("query slot lsn");
+            if let Some(row) = row {
+                return Some(row.get(0));
+            }
+            if time::Instant::now() >= deadline {
+                return None;
+            }
+        }
+    }
+
+    async fn teardown(self) {
+        let slot_literal = quote_literal(&self.slot);
+        let publication_ident = quote_ident(&self.publication);
+        let table_ident = quote_ident(&self.table);
+        let _ = self
+            .client
+            .simple_query(&format!(
+                "SELECT pg_drop_replication_slot({slot_literal}) WHERE EXISTS \
+                 (SELECT 1 FROM pg_replication_slots WHERE slot_name={slot_literal})"
+            ))
+            .await;
+        let _ = self
+            .client
+            .simple_query(&format!("DROP PUBLICATION IF EXISTS {publication_ident}"))
+            .await;
+        let _ = self
+            .client
+            .simple_query(&format!("DROP TABLE IF EXISTS {table_ident} CASCADE"))
+            .await;
+    }
+}
+
+/// Spawns the source with an auto-ack receiver (events marked Delivered when
+/// they reach the test consumer). Returns the receiver and a handle to abort
+/// the source task.
+async fn spawn_source(
+    config: PostgresqlCdcConfig,
+) -> (
+    impl Stream<Item = Event> + Unpin,
+    tokio::task::JoinHandle<()>,
+) {
+    let (sender, recv) =
+        SourceSender::new_test_finalize(vector_lib::finalization::EventStatus::Delivered);
+    let cx = SourceContext::new_test(sender, None);
+    let source_fut = config
+        .build(cx)
+        .await
+        .expect("source should build successfully");
+    let handle = tokio::spawn(async move {
+        let _ = source_fut.await;
+    });
+    (recv, handle)
+}
+
+/// Waits for `expected` events from the receiver with a generous timeout.
+async fn collect_events<S>(recv: &mut S, expected: usize, timeout_secs: u64) -> Vec<Event>
+where
+    S: Stream<Item = Event> + Unpin,
+{
+    let deadline = time::Instant::now() + Duration::from_secs(timeout_secs);
+    let mut events = Vec::with_capacity(expected);
+    while events.len() < expected {
+        let remaining = deadline.saturating_duration_since(time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match time::timeout(remaining, recv.next()).await {
+            Ok(Some(e)) => events.push(e),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    events
+}
+
+/// Collects events until `predicate` returns true for every accumulated event
+/// set, or `timeout_secs` elapses. Lets resume/reconnect tests stop waiting
+/// as soon as they've observed the expected new rows, rather than burning a
+/// fixed 30s timeout collecting noise from concurrent tests' logical
+/// messages.
+async fn collect_until<S, F>(recv: &mut S, mut predicate: F, timeout_secs: u64) -> Vec<Event>
+where
+    S: Stream<Item = Event> + Unpin,
+    F: FnMut(&[Event]) -> bool,
+{
+    let deadline = time::Instant::now() + Duration::from_secs(timeout_secs);
+    let mut events: Vec<Event> = Vec::new();
+    loop {
+        if predicate(&events) {
+            return events;
+        }
+        let remaining = deadline.saturating_duration_since(time::Instant::now());
+        if remaining.is_zero() {
+            return events;
+        }
+        match time::timeout(remaining, recv.next()).await {
+            Ok(Some(e)) => events.push(e),
+            Ok(None) | Err(_) => return events,
+        }
+    }
+}
+
+/// Filters a slice of events to row events emitted from the given table,
+/// dropping noise (e.g. `pg_logical_emit_message` events from concurrent
+/// tests, which are publication-independent and reach every slot on the
+/// server).
+fn filter_table_rows<'a>(events: &'a [Event], table: &str) -> Vec<&'a Event> {
+    events
+        .iter()
+        .filter(|e| {
+            let op = get_string(e, "operation");
+            (op == "insert" || op == "update" || op == "delete") && get_string(e, "table") == table
+        })
+        .collect()
+}
+
+fn get_field<'a>(event: &'a Event, key: &str) -> Option<&'a vrl::value::Value> {
+    event.as_log().get(key)
+}
+
+fn get_string(event: &Event, key: &str) -> String {
+    match get_field(event, key).unwrap_or_else(|| panic!("missing field {key}")) {
+        vrl::value::Value::Bytes(b) => String::from_utf8_lossy(b).to_string(),
+        other => panic!("field {key} not bytes: {other:?}"),
+    }
+}
+
+/// Parses a Postgres `X/Y` hex LSN to a `u64` so tests can compare LSNs by
+/// magnitude. Comparing the formatted strings lexicographically inverts at
+/// the first WAL segment boundary that grows the `X` half by a hex digit
+/// (e.g. `"16/0"` sorts before `"2/0"` while `0x16_0000_0000 > 0x2_0000_0000`).
+fn parse_lsn(s: &str) -> u64 {
+    let (hi, lo) = s
+        .split_once('/')
+        .unwrap_or_else(|| panic!("malformed LSN {s:?} (expected `X/Y` hex)"));
+    let hi =
+        u32::from_str_radix(hi, 16).unwrap_or_else(|_| panic!("LSN high half not hex: {hi:?}"));
+    let lo = u32::from_str_radix(lo, 16).unwrap_or_else(|_| panic!("LSN low half not hex: {lo:?}"));
+    (u64::from(hi) << 32) | u64::from(lo)
+}
+
+/// Double-quotes a PostgreSQL identifier and escapes embedded double quotes.
+/// Use this for any test SQL that interpolates a table, publication, or slot
+/// name into a DDL statement — even when the generator only produces
+/// alphanumeric names today, the helper prevents a future test fixture from
+/// silently becoming injection-vulnerable.
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Single-quotes a PostgreSQL string literal and escapes embedded single
+/// quotes. Used for slot-name arguments to functions like
+/// `pg_create_logical_replication_slot` and `pg_drop_replication_slot`,
+/// which take the slot name as a `text` argument.
+fn quote_literal(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+fn get_object(event: &Event, key: &str) -> vrl::value::ObjectMap {
+    match get_field(event, key).unwrap_or_else(|| panic!("missing field {key}")) {
+        vrl::value::Value::Object(m) => m.clone(),
+        other => panic!("field {key} not object: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_insert_produces_event() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, status TEXT)").await;
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'pending')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1, "expected exactly one event");
+    let ev = &events[0];
+    assert_eq!(get_string(ev, "operation"), "insert");
+    assert_eq!(get_string(ev, "table"), fixture.table);
+    let new = get_object(ev, "new");
+    assert_eq!(new.get("id").unwrap(), &vrl::value::Value::Integer(1));
+    assert_eq!(
+        new.get("status").unwrap(),
+        &vrl::value::Value::from("pending")
+    );
+    let lsn = get_string(ev, "lsn");
+    assert!(!lsn.is_empty() && lsn.contains('/'));
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_update_produces_event() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, status TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'pending'); \
+             UPDATE {} SET status='complete' WHERE id=1",
+            fixture.table, fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 2, 30).await;
+    assert_eq!(events.len(), 2);
+    assert_eq!(get_string(&events[0], "operation"), "insert");
+    assert_eq!(get_string(&events[1], "operation"), "update");
+    let new = get_object(&events[1], "new");
+    assert_eq!(
+        new.get("status").unwrap(),
+        &vrl::value::Value::from("complete")
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_delete_produces_event() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, status TEXT)").await;
+    // REPLICA IDENTITY FULL ensures the old row appears in the Delete message.
+    fixture
+        .client
+        .simple_query(&format!(
+            "ALTER TABLE {} REPLICA IDENTITY FULL",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'doomed'); DELETE FROM {} WHERE id=1",
+            fixture.table, fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 2, 30).await;
+    assert_eq!(events.len(), 2);
+    assert_eq!(get_string(&events[1], "operation"), "delete");
+    let old = get_object(&events[1], "old");
+    assert_eq!(old.get("id").unwrap(), &vrl::value::Value::Integer(1));
+    assert_eq!(
+        old.get("status").unwrap(),
+        &vrl::value::Value::from("doomed")
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_truncate_produces_event() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, status TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'a'), (2, 'b'); TRUNCATE {}",
+            fixture.table, fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 3, 30).await;
+    let truncate = events
+        .iter()
+        .find(|e| get_string(e, "operation") == "truncate")
+        .expect("truncate event");
+    assert_eq!(get_string(truncate, "table"), fixture.table);
+    assert_eq!(get_field(truncate, "new"), Some(&vrl::value::Value::Null));
+    assert_eq!(get_field(truncate, "old"), Some(&vrl::value::Value::Null));
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_multi_table_publication() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    let second = format!("{}_second", fixture.table);
+    fixture
+        .add_table_to_publication(
+            &second,
+            "CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)",
+        )
+        .await;
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (10, 'first'); INSERT INTO {} VALUES (20, 'second')",
+            fixture.table, second
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 2, 30).await;
+    let tables: Vec<String> = events.iter().map(|e| get_string(e, "table")).collect();
+    assert!(tables.contains(&fixture.table));
+    assert!(tables.contains(&second));
+
+    handle.abort();
+    let _ = fixture
+        .client
+        .simple_query(&format!("DROP TABLE IF EXISTS {second} CASCADE"))
+        .await;
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_lsn_advances_after_ack() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+
+    let before = fixture.confirmed_flush_lsn().await;
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'ack-test')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1);
+    // Dropping the events fires their BatchNotifiers as Delivered (the
+    // default). Give the source up to a few seconds to forward the
+    // confirmed LSN to Postgres.
+    drop(events);
+
+    let advanced = fixture
+        .wait_for_lsn_to_advance(before.clone(), Duration::from_secs(30))
+        .await;
+    assert!(
+        advanced.is_some(),
+        "confirmed_flush_lsn did not advance after sink ack (before={before:?})"
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_large_transaction_single_lsn() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    // Generate 1000 rows in one transaction.
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} SELECT generate_series(1, 1000)",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1000, 60).await;
+    assert_eq!(events.len(), 1000, "expected 1000 row events");
+    // All events share one LSN because they belong to a single transaction.
+    let lsn = get_string(&events[0], "lsn");
+    for ev in &events {
+        assert_eq!(get_string(ev, "lsn"), lsn);
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_reconnect_resumes_from_lsn() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+
+    // First source instance.
+    let before_first = fixture.confirmed_flush_lsn().await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'first')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+    let first = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(first.len(), 1);
+    let first_lsn = get_string(&first[0], "lsn");
+    assert_eq!(
+        get_object(&first[0], "new").get("id").unwrap(),
+        &vrl::value::Value::Integer(1)
+    );
+    drop(first);
+
+    // Wait until Postgres confirms the LSN has advanced AT OR PAST row 1's
+    // commit LSN. Just "advanced from baseline" is too weak — pgwire could
+    // checkpoint to a point mid-transaction.
+    let after_first = fixture
+        .wait_for_lsn_at_or_past(&first_lsn, Duration::from_secs(60))
+        .await;
+    assert!(
+        after_first.is_some(),
+        "confirmed_flush_lsn did not reach row 1's LSN ({first_lsn}) within 60s (before={before_first:?})"
+    );
+
+    handle.abort();
+    drop(recv);
+    // Give pgwire's drop a moment to release the slot.
+    time::sleep(Duration::from_secs(2)).await;
+
+    // New source instance, same slot. PostgreSQL's logical-replication
+    // guarantees are at-least-once, not exactly-once: the txn whose commit
+    // LSN equals confirmed_flush_lsn may legitimately be re-delivered on
+    // reconnect, so consumers must dedupe by LSN. What we test here is:
+    //   * no data loss — row 2 IS received
+    //   * LSN ordering — row 2's LSN is strictly greater than row 1's
+    //   * any re-delivered row 1 carries the same LSN it had originally
+    let (mut recv2, handle2) = spawn_source(fixture.config()).await;
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (2, 'second')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+    // Collect generously — other tests running in parallel emit
+    // `pg_logical_emit_message` events that reach every slot in the
+    // database (logical messages are publication-independent), and we
+    // don't want collect_events to bail out early on that noise before
+    // row 2 actually arrives.
+    let events = collect_events(&mut recv2, 30, 30).await;
+    let mut seen_row2 = false;
+    let mut last_lsn: Option<String> = None;
+    for ev in &events {
+        // Skip non-row events (truncate, message) — those have null `new`.
+        let op = get_string(ev, "operation");
+        if op != "insert" && op != "update" {
+            continue;
+        }
+        let id = get_object(ev, "new").get("id").cloned();
+        let lsn = get_string(ev, "lsn");
+        if let Some(prev) = &last_lsn {
+            assert!(
+                parse_lsn(&lsn) >= parse_lsn(prev),
+                "LSNs not ordered: {prev} -> {lsn}"
+            );
+        }
+        last_lsn = Some(lsn.clone());
+        if id == Some(vrl::value::Value::Integer(2)) {
+            seen_row2 = true;
+            assert!(
+                parse_lsn(&lsn) > parse_lsn(&first_lsn),
+                "row 2 LSN {lsn} not greater than row 1 LSN {first_lsn}"
+            );
+        }
+    }
+    assert!(
+        seen_row2,
+        "row 2 was never delivered (events received: {})",
+        events.len()
+    );
+
+    handle2.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_null_fields() {
+    trace_init();
+    let fixture =
+        CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, optional TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!("INSERT INTO {} VALUES (1, NULL)", fixture.table))
+        .await
+        .unwrap();
+
+    // Filter for our table to avoid flakes from concurrent tests'
+    // pg_logical_emit_message events reaching every slot.
+    let table_name = fixture.table.clone();
+    let events = collect_until(
+        &mut recv,
+        |events| !filter_table_rows(events, &table_name).is_empty(),
+        30,
+    )
+    .await;
+    let rows = filter_table_rows(&events, &fixture.table);
+    assert_eq!(rows.len(), 1);
+    let new = get_object(rows[0], "new");
+    assert_eq!(new.get("optional").unwrap(), &vrl::value::Value::Null);
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_replica_identity_nothing_insert_still_works() {
+    // REPLICA IDENTITY NOTHING is a valid (if unusual) configuration:
+    // PG forbids DELETE and UPDATE against the publication, but INSERT
+    // still emits row events. The parser must handle the no-replica-key
+    // case without crashing.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    fixture
+        .client
+        .simple_query(&format!(
+            "ALTER TABLE {} REPLICA IDENTITY NOTHING",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'inserted')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let table_name = fixture.table.clone();
+    let events = collect_until(
+        &mut recv,
+        |events| !filter_table_rows(events, &table_name).is_empty(),
+        30,
+    )
+    .await;
+    let rows = filter_table_rows(&events, &fixture.table);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(get_string(rows[0], "operation"), "insert");
+    let new = get_object(rows[0], "new");
+    assert_eq!(new.get("id").unwrap(), &vrl::value::Value::Integer(1));
+    assert_eq!(
+        new.get("label").unwrap(),
+        &vrl::value::Value::from("inserted")
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_replica_identity_index_delete_uses_index_columns() {
+    // REPLICA IDENTITY USING INDEX emits only the indexed columns in
+    // `old` for DELETE / UPDATE.
+    trace_init();
+    let fixture = CdcFixture::setup(
+        "CREATE TABLE {table} (id INT PRIMARY KEY, alt_key INT UNIQUE NOT NULL, label TEXT)",
+    )
+    .await;
+    let idx_name = format!("{}_alt_key_key", fixture.table);
+    fixture
+        .client
+        .simple_query(&format!(
+            "ALTER TABLE {} REPLICA IDENTITY USING INDEX {}",
+            fixture.table, idx_name
+        ))
+        .await
+        .unwrap();
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {0} VALUES (1, 100, 'doomed'); DELETE FROM {0} WHERE id=1",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let table_name = fixture.table.clone();
+    let events = collect_until(
+        &mut recv,
+        |events| filter_table_rows(events, &table_name).len() >= 2,
+        30,
+    )
+    .await;
+    let rows = filter_table_rows(&events, &fixture.table);
+    assert_eq!(rows.len(), 2);
+    let delete = rows
+        .iter()
+        .find(|e| get_string(e, "operation") == "delete")
+        .expect("expected a delete event");
+    let old = get_object(delete, "old");
+    // pgoutput emits one slot per column for the relation. Under
+    // REPLICA IDENTITY USING INDEX, only the indexed column carries the
+    // real value; every other column is sent as the NULL tuple-data kind
+    // (`'n'`), which our parser surfaces as `Value::Null`. This is the
+    // distinguishing wire-shape vs REPLICA IDENTITY FULL (all columns
+    // populated) and DEFAULT (primary-key columns populated, non-PK Null).
+    assert_eq!(
+        old.get("alt_key").unwrap(),
+        &vrl::value::Value::Integer(100)
+    );
+    assert_eq!(
+        old.get("id").unwrap(),
+        &vrl::value::Value::Null,
+        "id column should be Null (not populated) under REPLICA IDENTITY USING INDEX"
+    );
+    assert_eq!(
+        old.get("label").unwrap(),
+        &vrl::value::Value::Null,
+        "non-indexed column `label` should be Null"
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_emits_internal_metrics_for_source_compliance() {
+    // Verifies that the source emits the standard component_* metrics
+    // (ComponentReceivedBytesTotal, ComponentReceivedEventsTotal,
+    // ComponentReceivedEventBytesTotal) tagged with `protocol`, which is
+    // what Vector's `assert_source_compliance` checks for. Without this,
+    // operators have no way to monitor the source's throughput.
+    use crate::test_util::components::{SOURCE_TAGS, assert_source_compliance};
+
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+
+    assert_source_compliance(&SOURCE_TAGS, async {
+        let (mut recv, handle) = spawn_source(fixture.config()).await;
+        fixture
+            .client
+            .simple_query(&format!(
+                "INSERT INTO {} VALUES (1, 'metric_check')",
+                fixture.table
+            ))
+            .await
+            .unwrap();
+        let table_name = fixture.table.clone();
+        let _ = collect_until(
+            &mut recv,
+            |events| !filter_table_rows(events, &table_name).is_empty(),
+            30,
+        )
+        .await;
+        handle.abort();
+    })
+    .await;
+
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_dropped_event_advances_lsn() {
+    // A "dropped" event in Vector still surfaces as BatchStatus::Delivered,
+    // so this test verifies that the source advances the LSN even though
+    // no downstream sink consumed the event in the conventional sense.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    let before = fixture.confirmed_flush_lsn().await;
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'drop-me')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    // Consume the event. spawn_source uses new_test_finalize(Delivered) so
+    // dropping the event triggers the Delivered batch status; that's the
+    // same path a VRL drop transform would take (Dropped → Delivered at
+    // the batch level).
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1);
+    drop(events);
+
+    let advanced = fixture
+        .wait_for_lsn_to_advance(before.clone(), Duration::from_secs(30))
+        .await;
+    assert!(
+        advanced.is_some(),
+        "LSN should advance even for dropped events"
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_numeric_preserved_as_string() {
+    trace_init();
+    let fixture =
+        CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, amount NUMERIC(30, 15))")
+            .await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    // Insert a value that f64 cannot represent exactly.
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 1.234567890123456)",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1);
+    let new = get_object(&events[0], "new");
+    match new.get("amount").unwrap() {
+        vrl::value::Value::Bytes(b) => {
+            let s = String::from_utf8_lossy(b);
+            assert!(
+                s.starts_with("1.234567890123456"),
+                "numeric truncated/rounded: {s}"
+            );
+        }
+        other => panic!("expected NUMERIC as Bytes, got {other:?}"),
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_jsonb_bytea_and_timestamptz_roundtrip() {
+    // End-to-end coverage for the typed-column decode path against a live
+    // PG. The pgoutput parser unit tests already cover the OID-to-`Value`
+    // mapping in isolation, but this test catches regressions where the
+    // Relation message's type OIDs do not reach `decode_value` correctly
+    // (e.g. column ordering, repeated parses, schema cache eviction).
+    trace_init();
+    let fixture = CdcFixture::setup(
+        "CREATE TABLE {table} ( \
+         id INT PRIMARY KEY, \
+         payload JSONB, \
+         raw BYTEA, \
+         ts TIMESTAMPTZ \
+         )",
+    )
+    .await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES \
+             (1, '{{\"x\": 42, \"y\": [true, null]}}'::jsonb, \
+              '\\x010203fe'::bytea, \
+              '2025-06-01 12:34:56+00'::timestamptz)",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1, "expected one insert event");
+    let new = get_object(&events[0], "new");
+
+    // jsonb → Value::Object
+    match new.get("payload").unwrap() {
+        vrl::value::Value::Object(map) => {
+            assert_eq!(map.get("x"), Some(&vrl::value::Value::Integer(42)));
+        }
+        other => panic!("expected jsonb as Object, got {other:?}"),
+    }
+
+    // bytea → Value::Bytes of the decoded hex bytes
+    match new.get("raw").unwrap() {
+        vrl::value::Value::Bytes(b) => assert_eq!(b.as_ref(), &[0x01, 0x02, 0x03, 0xFE]),
+        other => panic!("expected bytea as raw Bytes, got {other:?}"),
+    }
+
+    // timestamptz → Value::Bytes containing PG's ISO-8601 text. We assert
+    // on the prefix to avoid coupling to the server's timezone-display
+    // settings; the value-shape contract is "PG's text form, untouched".
+    match new.get("ts").unwrap() {
+        vrl::value::Value::Bytes(b) => {
+            let s = String::from_utf8_lossy(b);
+            assert!(
+                s.starts_with("2025-06-01"),
+                "timestamptz text payload not preserved: {s}"
+            );
+        }
+        other => panic!("expected timestamptz as Bytes (ISO-8601 text), got {other:?}"),
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_transactional_logical_message_emitted() {
+    // pg_logical_emit_message(true, prefix, content) inside a transaction
+    // travels through the slot tagged with the transaction's commit LSN.
+    // The source should surface it as a `message` event.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "BEGIN; \
+             INSERT INTO {} VALUES (1); \
+             SELECT pg_logical_emit_message(true, 'vector.test', 'tx-payload'); \
+             COMMIT;",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 2, 30).await;
+    assert_eq!(events.len(), 2, "expected insert + message");
+    let msg = events
+        .iter()
+        .find(|e| get_string(e, "operation") == "message")
+        .expect("expected a message event");
+    let row = events
+        .iter()
+        .find(|e| get_string(e, "operation") == "insert")
+        .expect("expected an insert event");
+
+    // Both share the txn's LSN.
+    assert_eq!(get_string(msg, "lsn"), get_string(row, "lsn"));
+    assert_eq!(
+        get_field(msg, "transactional"),
+        Some(&vrl::value::Value::Boolean(true))
+    );
+    assert_eq!(get_string(msg, "prefix"), "vector.test");
+    match get_field(msg, "content").unwrap() {
+        vrl::value::Value::Bytes(b) => {
+            assert_eq!(&b[..], b"tx-payload");
+        }
+        other => panic!("content not bytes: {other:?}"),
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_logical_message_binary_payload_roundtrips() {
+    // `pg_logical_emit_message` accepts either a text or bytea payload. The
+    // bytea variant is meant for arbitrary binary content — null bytes,
+    // non-UTF-8 bytes, the works — and our handling must preserve every
+    // byte exactly. (`Value::Bytes` stores a raw `Bytes`, so the bytes are
+    // intact through the source; what we're proving here is that we don't
+    // accidentally try to UTF-8 decode along the way.)
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    // Payload: 0x00 (embedded null), 0xFF (high byte, invalid UTF-8 lead),
+    // 0xFE, 0xC0 (UTF-8 invalid in any position), then printable text.
+    fixture
+        .client
+        .simple_query(
+            "SELECT pg_logical_emit_message(false, 'vector.bin', \
+             '\\x00ffFEc0' || 'hello'::bytea)",
+        )
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1);
+    let msg = &events[0];
+    assert_eq!(get_string(msg, "operation"), "message");
+    assert_eq!(get_string(msg, "prefix"), "vector.bin");
+    match get_field(msg, "content").unwrap() {
+        vrl::value::Value::Bytes(b) => {
+            assert_eq!(
+                &b[..],
+                &[0x00, 0xFF, 0xFE, 0xC0, b'h', b'e', b'l', b'l', b'o'][..],
+                "binary message content was not preserved byte-for-byte"
+            );
+        }
+        other => panic!("content not bytes: {other:?}"),
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_non_transactional_logical_message_emitted() {
+    // pg_logical_emit_message(false, prefix, content) is delivered
+    // immediately and carries its own LSN — not tied to any surrounding
+    // transaction.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query("SELECT pg_logical_emit_message(false, 'vector.heartbeat', 'beat')")
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1, "expected one message event");
+    let msg = &events[0];
+    assert_eq!(get_string(msg, "operation"), "message");
+    assert_eq!(
+        get_field(msg, "transactional"),
+        Some(&vrl::value::Value::Boolean(false))
+    );
+    assert_eq!(get_string(msg, "prefix"), "vector.heartbeat");
+    // Non-transactional messages MUST NOT carry txn metadata. We assert
+    // absence (key not present) rather than presence-of-`null`, so that
+    // downstream consumers can distinguish "no transaction" from "field
+    // explicitly null".
+    assert_eq!(get_field(msg, "transaction_id"), None);
+    assert_eq!(get_field(msg, "transaction_timestamp"), None);
+    assert_eq!(get_field(msg, "new"), None);
+    assert_eq!(get_field(msg, "old"), None);
+    assert_eq!(get_field(msg, "schema"), None);
+    assert_eq!(get_field(msg, "table"), None);
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_transaction_rollback_emits_no_events() {
+    // Sanity: a transaction that ROLLBACKs must not produce any events,
+    // and must not affect the slot's confirmed_flush_lsn beyond what an
+    // empty txn would. This is one of the most basic CDC safety properties.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "BEGIN; INSERT INTO {} VALUES (1, 'rolled-back'); ROLLBACK;",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    // Then a committed insert to give the receiver something to deliver,
+    // proving the source isn't simply blocked.
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (2, 'committed')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(events.len(), 1, "rollback must not produce events");
+    let new = get_object(&events[0], "new");
+    assert_eq!(new.get("id").unwrap(), &vrl::value::Value::Integer(2));
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_concurrent_writers_lsn_ordered() {
+    // pgoutput guarantees non-interleaved transaction delivery: txn A is
+    // either fully emitted before txn B's first event, or fully after.
+    // This test exercises that property using two distinct client
+    // connections committing concurrently, and verifies that:
+    //   * every row is delivered exactly once
+    //   * LSNs are strictly non-decreasing in receive order
+    //   * events from the same transaction share one LSN
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, src TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    // Two extra connections, each running a small txn concurrently.
+    let endpoint = fixture.endpoint.clone();
+    let table = fixture.table.clone();
+    let writer1 = tokio::spawn(async move {
+        let (c, conn) = tokio_postgres::connect(&endpoint, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        c.simple_query(&format!(
+            "INSERT INTO {table} VALUES (10, 'writer1'), (11, 'writer1')"
+        ))
+        .await
+        .unwrap();
+    });
+    let endpoint = fixture.endpoint.clone();
+    let table = fixture.table.clone();
+    let writer2 = tokio::spawn(async move {
+        let (c, conn) = tokio_postgres::connect(&endpoint, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        c.simple_query(&format!(
+            "INSERT INTO {table} VALUES (20, 'writer2'), (21, 'writer2')"
+        ))
+        .await
+        .unwrap();
+    });
+
+    writer1.await.unwrap();
+    writer2.await.unwrap();
+
+    let events = collect_events(&mut recv, 4, 30).await;
+    assert_eq!(events.len(), 4, "expected 4 events from 2 concurrent txns");
+
+    // LSNs must be non-decreasing in delivery order.
+    let lsns: Vec<String> = events.iter().map(|e| get_string(e, "lsn")).collect();
+    for w in lsns.windows(2) {
+        assert!(
+            parse_lsn(&w[0]) <= parse_lsn(&w[1]),
+            "LSN regression: {} -> {}",
+            w[0],
+            w[1]
+        );
+    }
+
+    // Each transaction's events share one LSN. Group by `src` and verify.
+    let mut by_src: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for ev in &events {
+        let src = match get_object(ev, "new").get("src") {
+            Some(vrl::value::Value::Bytes(b)) => String::from_utf8_lossy(b).to_string(),
+            _ => panic!("missing src"),
+        };
+        by_src.entry(src).or_default().push(get_string(ev, "lsn"));
+    }
+    for (src, lsns) in &by_src {
+        let first = &lsns[0];
+        for l in lsns {
+            assert_eq!(l, first, "rows from {src} carry different LSNs: {lsns:?}");
+        }
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_dropped_table_does_not_break_stream() {
+    // Inspired by Debezium's shouldIgnoreEventsForDeletedTable. If a
+    // published table is dropped mid-stream, subsequent writes to OTHER
+    // published tables must continue to be delivered. The publication
+    // implicitly stops covering the dropped table; we should not crash.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, v TEXT)").await;
+    let doomed = format!("{}_doomed", fixture.table);
+    fixture
+        .add_table_to_publication(&doomed, "CREATE TABLE {table} (id INT PRIMARY KEY)")
+        .await;
+
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!("INSERT INTO {doomed} VALUES (1)"))
+        .await
+        .unwrap();
+    let _ = collect_events(&mut recv, 1, 30).await;
+
+    // Drop the doomed table. Subsequent inserts to the main table must
+    // still flow.
+    fixture
+        .client
+        .simple_query(&format!("DROP TABLE {doomed}"))
+        .await
+        .unwrap();
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (100, 'alive')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let post_drop = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(post_drop.len(), 1, "main table events must still flow");
+    let new = get_object(&post_drop[0], "new");
+    assert_eq!(new.get("id").unwrap(), &vrl::value::Value::Integer(100));
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_mixed_dml_single_transaction() {
+    // Multiple operations inside one BEGIN/COMMIT must all share one LSN.
+    // This is the invariant the LsnTracker's Vec-per-LSN shape exists to
+    // protect: a single ack of a multi-row transaction must move the slot
+    // exactly once, not once per row.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    fixture
+        .client
+        .simple_query(&format!(
+            "ALTER TABLE {} REPLICA IDENTITY FULL",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "BEGIN; \
+             INSERT INTO {0} VALUES (1, 'a'), (2, 'b'); \
+             UPDATE {0} SET label='aa' WHERE id=1; \
+             DELETE FROM {0} WHERE id=2; \
+             COMMIT;",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let events = collect_events(&mut recv, 4, 30).await;
+    assert_eq!(events.len(), 4, "expected 4 row events from one txn");
+    let ops: Vec<String> = events.iter().map(|e| get_string(e, "operation")).collect();
+    assert_eq!(ops, vec!["insert", "insert", "update", "delete"]);
+    // All four events must carry the same LSN (the txn's commit LSN).
+    let lsn = get_string(&events[0], "lsn");
+    for ev in &events[1..] {
+        assert_eq!(get_string(ev, "lsn"), lsn);
+    }
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_many_transactions_slot_advances_continuously() {
+    // Sustained throughput: push 50 small transactions and confirm the slot
+    // advances multiple times (not just once at the end). Catches a class
+    // of bugs where LSN advancement only happens on shutdown or where a
+    // missing wake breaks steady-state progress.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    let start = fixture.confirmed_flush_lsn().await;
+    let mut milestones = Vec::new();
+    for batch in 0..5 {
+        for i in 0..10 {
+            let id = batch * 10 + i;
+            fixture
+                .client
+                .simple_query(&format!(
+                    "INSERT INTO {} VALUES ({id}, 'row{id}')",
+                    fixture.table
+                ))
+                .await
+                .unwrap();
+        }
+        // Drain the 10 events for this batch so their batches finalize.
+        let _ = collect_events(&mut recv, 10, 30).await;
+        // Sample LSN periodically.
+        time::sleep(Duration::from_millis(750)).await;
+        milestones.push(fixture.confirmed_flush_lsn().await);
+    }
+
+    // We expect milestones to strictly advance through the 5 sample points.
+    let distinct: std::collections::HashSet<_> = milestones.iter().collect();
+    assert!(
+        distinct.len() >= 3,
+        "confirmed_flush_lsn should advance multiple times during sustained \
+         insertion. Saw milestones: {milestones:?} (start={start:?})"
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_resume_does_not_replay_acked_transactions() {
+    // Realistic resume scenario: many committed-and-ack'd transactions
+    // followed by a reconnect, followed by a few new transactions.
+    //
+    // PostgreSQL logical replication is at-least-once: the *very last*
+    // acked transaction may be re-delivered (this is by design — see the
+    // test_reconnect_resumes_from_lsn comment). What MUST hold is that we
+    // do NOT replay the entire history. This test catches the failure
+    // mode where the slot fails to advance and every reconnect re-streams
+    // everything from creation.
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY)").await;
+    let (mut recv1, handle1) = spawn_source(fixture.config()).await;
+    // 25 individual transactions before the reconnect.
+    for i in 0..25 {
+        fixture
+            .client
+            .simple_query(&format!("INSERT INTO {} VALUES ({i})", fixture.table))
+            .await
+            .unwrap();
+    }
+    let phase1 = collect_events(&mut recv1, 25, 60).await;
+    assert_eq!(phase1.len(), 25);
+    // Capture the LSN of the *last* phase-1 event. We must wait for the
+    // slot to advance to (or past) this LSN before killing the source —
+    // otherwise the still-unacked tail will be re-delivered on resume and
+    // we'd fail the strict `phase2.len() < 10` check.
+    let last_phase1_lsn = get_string(phase1.last().unwrap(), "lsn");
+    drop(phase1);
+
+    let advanced = fixture
+        .wait_for_lsn_at_or_past(&last_phase1_lsn, Duration::from_secs(60))
+        .await;
+    assert!(
+        advanced.is_some(),
+        "slot did not reach the last phase-1 LSN ({last_phase1_lsn}) within 60s"
+    );
+
+    handle1.abort();
+    drop(recv1);
+    time::sleep(Duration::from_secs(2)).await;
+
+    // Reconnect. Insert 3 new rows.
+    let (mut recv2, handle2) = spawn_source(fixture.config()).await;
+    for i in 25..28 {
+        fixture
+            .client
+            .simple_query(&format!("INSERT INTO {} VALUES ({i})", fixture.table))
+            .await
+            .unwrap();
+    }
+
+    // Collect with an early-exit: once we've seen all 3 new IDs, stop
+    // waiting. This avoids burning the full timeout collecting concurrent
+    // tests' message events. The 15s outer bound is well above the
+    // sub-second arrival we expect.
+    let table_name = fixture.table.clone();
+    let phase2 = collect_until(
+        &mut recv2,
+        |events| {
+            let ids: std::collections::HashSet<i64> = filter_table_rows(events, &table_name)
+                .iter()
+                .filter_map(|e| match get_object(e, "new").get("id") {
+                    Some(vrl::value::Value::Integer(i)) => Some(*i),
+                    _ => None,
+                })
+                .collect();
+            (25i64..28).all(|id| ids.contains(&id))
+        },
+        15,
+    )
+    .await;
+
+    // Strict accounting: out of phase2, count only inserts on our table.
+    // We MUST see rows 25, 26, 27 (the new ones). We may see up to one
+    // re-delivered row (PG's at-least-once guarantee on the last-acked
+    // txn). Anything beyond `3 + 1 = 4` row events means the slot failed
+    // to advance and the resume mechanism is broken.
+    let inserts: Vec<&Event> = filter_table_rows(&phase2, &fixture.table);
+    let ids: Vec<i64> = inserts
+        .iter()
+        .filter_map(|e| match get_object(e, "new").get("id") {
+            Some(vrl::value::Value::Integer(i)) => Some(*i),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        inserts.len() <= 4,
+        "resume re-played too many transactions: got {} row events from {}, expected 3 (and at most 1 re-delivered). ids={ids:?}",
+        inserts.len(),
+        fixture.table,
+    );
+    for new_id in 25i64..28 {
+        assert!(
+            ids.contains(&new_id),
+            "new row id={new_id} not delivered after resume; got ids={ids:?}"
+        );
+    }
+
+    handle2.abort();
+    fixture.teardown().await;
+}
+
+#[tokio::test]
+async fn test_schema_change_invalidates_relation_cache() {
+    trace_init();
+    let fixture = CdcFixture::setup("CREATE TABLE {table} (id INT PRIMARY KEY, label TEXT)").await;
+    let (mut recv, handle) = spawn_source(fixture.config()).await;
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} VALUES (1, 'before')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+    let first = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(first.len(), 1);
+
+    fixture
+        .client
+        .simple_query(&format!(
+            "ALTER TABLE {} ADD COLUMN extra TEXT",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+    fixture
+        .client
+        .simple_query(&format!(
+            "INSERT INTO {} (id, label, extra) VALUES (2, 'after', 'new-col')",
+            fixture.table
+        ))
+        .await
+        .unwrap();
+
+    let second = collect_events(&mut recv, 1, 30).await;
+    assert_eq!(second.len(), 1);
+    let new = get_object(&second[0], "new");
+    assert_eq!(
+        new.get("extra").unwrap(),
+        &vrl::value::Value::from("new-col")
+    );
+
+    handle.abort();
+    fixture.teardown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Throughput benchmarks — gated behind `postgresql_cdc-benchmarks`.
+//
+// These are integration tests (not Criterion) because they need a live PG.
+// Run via:
+//
+//   cargo vdev int start postgresql_cdc
+//   cargo test -p vector \
+//     --features postgresql_cdc-benchmarks --no-default-features \
+//     --lib sources::postgresql_cdc::integration_tests::bench \
+//     -- --nocapture
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "postgresql_cdc-benchmarks")]
+mod bench {
+    use super::*;
+    use vector_lib::EstimatedJsonEncodedSizeOf;
+
+    async fn run_throughput_bench(row_count: u64) {
+        trace_init();
+        let fixture = CdcFixture::setup(
+            "CREATE TABLE {table} ( \
+             id BIGINT PRIMARY KEY, \
+             label TEXT NOT NULL, \
+             amount NUMERIC(12,2) NOT NULL, \
+             payload JSONB NOT NULL \
+             )",
+        )
+        .await;
+
+        // Bulk-insert before starting the source so WAL is pre-buffered.
+        // Each row is ~120 bytes of WAL (4 typed columns). The INSERT runs
+        // in a single transaction: pgoutput emits Begin, N Inserts, Commit.
+        let insert_sql = format!(
+            "INSERT INTO {} (id, label, amount, payload) \
+             SELECT g, \
+                    'row-' || g, \
+                    (g % 100000)::numeric / 100, \
+                    jsonb_build_object('seq', g, 'tag', 'bench') \
+             FROM generate_series(1, {row_count}) g",
+            fixture.table
+        );
+        let t0 = std::time::Instant::now();
+        fixture
+            .client
+            .simple_query(&insert_sql)
+            .await
+            .expect("bulk insert");
+        let insert_dur = t0.elapsed();
+        println!(
+            "[bench] Inserted {row_count} rows in {:.2}s ({:.0} rows/s)",
+            insert_dur.as_secs_f64(),
+            row_count as f64 / insert_dur.as_secs_f64()
+        );
+
+        // Drain events with an O(n) counter instead of the O(n²)
+        // collect_until + filter_table_rows combination that rescans the
+        // entire accumulated vector on every arrival.
+        let (mut recv, handle) = spawn_source(fixture.config()).await;
+        let t1 = std::time::Instant::now();
+        let table_name = fixture.table.clone();
+        let mut events: Vec<Event> = Vec::with_capacity(row_count as usize + 64);
+        let mut row_count_seen: u64 = 0;
+        let deadline = time::Instant::now() + Duration::from_secs(600);
+        while row_count_seen < row_count {
+            let remaining = deadline.saturating_duration_since(time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match time::timeout(remaining, recv.next()).await {
+                Ok(Some(e)) => {
+                    let op = get_string(&e, "operation");
+                    let is_row = (op == "insert" || op == "update" || op == "delete")
+                        && get_string(&e, "table") == table_name;
+                    if is_row {
+                        row_count_seen += 1;
+                    }
+                    events.push(e);
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+        let consume_dur = t1.elapsed();
+
+        let total_events = events.len();
+        let total_bytes: usize = events
+            .iter()
+            .map(|e| e.estimated_json_encoded_size_of().get())
+            .sum();
+
+        println!(
+            "[bench] Consumed {total_events} events ({row_count_seen} row events) in {:.2}s",
+            consume_dur.as_secs_f64()
+        );
+        println!(
+            "[bench] Throughput: {:.0} events/s, {:.1} MB/s (estimated JSON size)",
+            total_events as f64 / consume_dur.as_secs_f64(),
+            total_bytes as f64 / consume_dur.as_secs_f64() / 1_048_576.0
+        );
+        assert_eq!(
+            row_count_seen, row_count,
+            "expected {row_count} row events, got {row_count_seen}"
+        );
+
+        handle.abort();
+        fixture.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn bench_100k_rows() {
+        run_throughput_bench(100_000).await;
+    }
+
+    #[tokio::test]
+    async fn bench_1m_rows() {
+        run_throughput_bench(1_000_000).await;
+    }
+}

--- a/src/sources/postgresql_cdc/lsn_tracker.rs
+++ b/src/sources/postgresql_cdc/lsn_tracker.rs
@@ -1,0 +1,434 @@
+//! In-flight LSN tracking for the `postgresql_cdc` source.
+//!
+//! pgoutput emits row events without their own LSN: every Insert/Update/Delete
+//! within a transaction shares the `final_lsn` carried by that transaction's
+//! Begin message. A single 10,000-row transaction therefore produces 10,000
+//! events all tagged with one LSN, and only when *every* event has been
+//! acknowledged by the sink may we report that LSN as flushed to Postgres.
+//!
+//! The tracker stores a `Vec<BatchStatusReceiver>` per LSN and only advances
+//! `confirmed_lsn` through the longest contiguous prefix of the map where each
+//! LSN's full Vec has resolved. It uses `try_recv()` exclusively so it never
+//! blocks the replication loop.
+//!
+//! ## Why not `vector_lib::finalizer::OrderedFinalizer`?
+//!
+//! `OrderedFinalizer<E>` (used by `kafka.rs` and `splunk_hec.rs`) tracks one
+//! finalizer per event-key and emits acks in the order entries were added.
+//! That fits Kafka where each message has its own offset, but it does not
+//! model "many events share one LSN": you'd either need to use the same key
+//! for every row in a txn (which loses per-LSN granularity) or emit one
+//! finalizer per row (which would advance the LSN partway through a txn,
+//! breaking at-least-once on restart). The custom `LsnTracker` here exists
+//! specifically to handle the LSN-grouping semantics — if a future change
+//! makes Postgres deliver one LSN per row, switching to `OrderedFinalizer`
+//! would be appropriate.
+//!
+//! ## Status handling
+//!
+//! Vector's `BatchStatus` collapses `EventStatus::Dropped` into
+//! `BatchStatus::Delivered` (see `lib/vector-common/src/finalization.rs`), so
+//! a VRL filter that drops events surfaces here as `Delivered` and naturally
+//! advances the LSN without leaking memory. `Errored` and `Rejected` halt
+//! advancement and the source surfaces the failure upstream.
+//!
+//! `TryRecvError::Closed` (sender dropped without sending) is logged at
+//! `warn` and treated as `Delivered`. Hard-failing on this matches neither
+//! Vector's `kafka` source (which logs and continues) nor the broader
+//! finalization conventions, and would cause spurious source restarts when
+//! downstream components are reconfigured.
+
+use std::collections::BTreeMap;
+
+use tokio::sync::oneshot::error::TryRecvError;
+use vector_lib::event::{BatchStatus, BatchStatusReceiver};
+
+/// Maximum number of distinct in-flight transaction LSNs we will track
+/// before applying back-pressure (pausing `client.recv()`).
+///
+/// **Derivation:** each pending entry is a `BTreeMap` key (`u64`, 8 bytes)
+/// plus a `Vec<BatchStatusReceiver>` (24 bytes header + ~40 bytes per
+/// receiver). For the common single-batch-per-transaction case that is
+/// ~72 bytes/entry, so 100K entries ≈ 7 MB. A database sustaining 1K
+/// committed transactions per second would need the sink to stall for
+/// ~100 seconds before this cap is reached — well past the point where
+/// an operator would notice via lag metrics. The cap is deliberately
+/// generous: its purpose is not to be tight, but to guarantee that a
+/// permanently-stalled sink eventually pauses the replication stream
+/// instead of growing the map without bound. See the
+/// `postgresql_cdc-benchmarks` feature for memory-profile tests at
+/// different cap values.
+const MAX_PENDING_LSNS: usize = 100_000;
+
+/// Outcome of polling a single LSN's batch receivers.
+enum LsnPollOutcome {
+    /// Every receiver for this LSN resolved with `Delivered`.
+    Resolved,
+    /// At least one receiver is still pending; we must stop advancing here.
+    Pending,
+    /// A receiver returned `Errored` or `Rejected`. The caller must halt
+    /// LSN advancement.
+    Failed(BatchStatus),
+}
+
+/// Tracks pending transaction LSNs and their sink acknowledgment status.
+///
+/// Receivers for the same LSN accumulate in a single `Vec` rather than
+/// overwriting, because every row in one transaction shares one LSN.
+///
+/// Invariant: `confirmed_lsn` is only ever advanced to an LSN whose Vec is
+/// fully resolved, and only when every LSN strictly less than it has already
+/// been removed from `pending`.
+#[derive(Default)]
+pub(super) struct LsnTracker {
+    pending: BTreeMap<u64, Vec<BatchStatusReceiver>>,
+    confirmed_lsn: u64,
+    /// The value most recently returned by `poll_confirmed`. Used to make
+    /// poll edge-triggered: returns `Some` only when progress has been made
+    /// since the last call.
+    last_reported: u64,
+    failed: Option<(u64, BatchStatus)>,
+}
+
+impl LsnTracker {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new receiver for the given LSN.
+    ///
+    /// Multiple calls with the same LSN append to that LSN's Vec — they do
+    /// not overwrite. In practice LSNs are monotonically non-decreasing in
+    /// pgoutput's commit order, so this is the natural shape for tracking
+    /// 1-to-many rows-per-transaction.
+    pub(super) fn track(&mut self, lsn: u64, receiver: BatchStatusReceiver) {
+        self.pending.entry(lsn).or_default().push(receiver);
+    }
+
+    /// Records that the given LSN can be reported as flushed immediately,
+    /// without waiting on any sink acknowledgement. Used in at-most-once
+    /// mode (the no-ack path) to keep the slot moving — otherwise PG would
+    /// retain WAL forever.
+    pub(super) const fn mark_delivered_immediately(&mut self, lsn: u64) {
+        if lsn > self.confirmed_lsn && self.failed.is_none() {
+            self.confirmed_lsn = lsn;
+        }
+    }
+
+    /// Returns `true` if the pending map has reached the back-pressure cap.
+    /// The caller (the replication loop) should stop pulling new events
+    /// from the wire until `poll_confirmed` drains entries below the cap.
+    pub(super) fn is_full(&self) -> bool {
+        self.pending.len() >= MAX_PENDING_LSNS
+    }
+
+    /// Non-blocking poll over all pending LSNs in ascending order.
+    ///
+    /// Advances `confirmed_lsn` through the longest contiguous prefix of the
+    /// pending map where every receiver has returned `Delivered`. Returns the
+    /// new `confirmed_lsn` if it advanced (either via batch resolution or via
+    /// a prior `mark_delivered_immediately` call), otherwise `None`.
+    ///
+    /// Never `.await`s a receiver — uses `try_recv()` exclusively so the
+    /// replication loop is never blocked behind a slow sink. Allocates
+    /// nothing on the hot path.
+    pub(super) fn poll_confirmed(&mut self) -> Option<u64> {
+        if self.failed.is_some() {
+            // Even if mark_delivered_immediately bumped confirmed_lsn
+            // earlier, do not report further progress once a failure has
+            // been observed.
+            return None;
+        }
+
+        // Walk the map in ascending order. `BTreeMap::iter_mut` is sorted,
+        // so we can break at the first non-resolved entry to honour the
+        // contiguous-prefix invariant. We collect the keys to remove via
+        // `to_remove_upto` and prune in one pass after the loop, avoiding
+        // both the per-poll Vec-of-keys allocation and the mid-iteration
+        // mutation issue.
+        let mut last_resolved: Option<u64> = None;
+        for (&lsn, entry) in self.pending.iter_mut() {
+            match poll_one_lsn(entry) {
+                LsnPollOutcome::Resolved => {
+                    last_resolved = Some(lsn);
+                }
+                LsnPollOutcome::Pending => break,
+                LsnPollOutcome::Failed(status) => {
+                    self.failed = Some((lsn, status));
+                    break;
+                }
+            }
+        }
+
+        if let Some(upto) = last_resolved {
+            // Remove every entry with key <= upto in one pass. `split_off`
+            // returns the entries with key >= upto+1, leaving the resolved
+            // prefix in `self.pending`, which we then clear.
+            let tail = self.pending.split_off(&(upto.saturating_add(1)));
+            self.pending.clear();
+            self.pending = tail;
+            self.confirmed_lsn = upto;
+        }
+
+        if self.confirmed_lsn > self.last_reported {
+            self.last_reported = self.confirmed_lsn;
+            Some(self.confirmed_lsn)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the (lsn, status) pair of the first observed failure, if any.
+    /// Once set, the tracker will not advance further.
+    pub(super) const fn failure(&self) -> Option<(u64, BatchStatus)> {
+        self.failed
+    }
+
+    #[cfg(test)]
+    pub(super) const fn confirmed_lsn(&self) -> u64 {
+        self.confirmed_lsn
+    }
+
+    #[cfg(test)]
+    pub(super) fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+/// Polls every receiver in `receivers`, draining the ones that have resolved.
+///
+/// Resolved receivers (`Delivered`) are removed. A receiver returning
+/// `Errored` / `Rejected` returns `Failed` immediately. A `Closed` sender
+/// (dropped without sending) is logged and treated as `Delivered` — matches
+/// the kafka source's behaviour and avoids killing the source when a
+/// downstream component is reconfigured. If any receiver is still pending,
+/// returns `Pending`. If the slice is emptied, returns `Resolved`.
+fn poll_one_lsn(receivers: &mut Vec<BatchStatusReceiver>) -> LsnPollOutcome {
+    let mut i = 0;
+    while i < receivers.len() {
+        match receivers[i].try_recv() {
+            Ok(BatchStatus::Delivered) => {
+                receivers.swap_remove(i);
+            }
+            Ok(status @ (BatchStatus::Errored | BatchStatus::Rejected)) => {
+                return LsnPollOutcome::Failed(status);
+            }
+            Err(TryRecvError::Empty) => {
+                i += 1;
+            }
+            Err(TryRecvError::Closed) => {
+                tracing::warn!(
+                    message = "BatchStatusReceiver sender dropped without sending; \
+                               treating as Delivered. This usually indicates a \
+                               downstream component was reconfigured mid-stream."
+                );
+                receivers.swap_remove(i);
+            }
+        }
+    }
+
+    if receivers.is_empty() {
+        LsnPollOutcome::Resolved
+    } else {
+        LsnPollOutcome::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vector_lib::event::{BatchNotifier, EventFinalizer};
+    use vector_lib::finalization::EventStatus;
+
+    /// Creates a fresh batch and its receiver.
+    fn new_batch() -> (BatchNotifier, BatchStatusReceiver) {
+        BatchNotifier::new_with_receiver()
+    }
+
+    /// Drops the batch with the default `Delivered` outcome.
+    fn deliver(b: BatchNotifier) {
+        drop(b);
+    }
+
+    /// Drops the batch after marking an attached event finalizer as `Errored`.
+    fn errored(b: BatchNotifier) {
+        let f = EventFinalizer::new(b);
+        f.update_status(EventStatus::Errored);
+        drop(f);
+    }
+
+    #[test]
+    fn empty_tracker_returns_none() {
+        let mut t = LsnTracker::new();
+        assert_eq!(t.poll_confirmed(), None);
+        assert_eq!(t.confirmed_lsn(), 0);
+    }
+
+    #[test]
+    fn single_lsn_advances_after_ack() {
+        let mut t = LsnTracker::new();
+        let (b, r) = new_batch();
+        t.track(100, r);
+
+        assert_eq!(t.poll_confirmed(), None);
+
+        deliver(b);
+
+        assert_eq!(t.poll_confirmed(), Some(100));
+        assert_eq!(t.confirmed_lsn(), 100);
+    }
+
+    #[test]
+    fn multiple_receivers_one_lsn_all_must_resolve() {
+        let mut t = LsnTracker::new();
+        let mut batches = Vec::new();
+        for _ in 0..10 {
+            let (b, r) = new_batch();
+            t.track(200, r);
+            batches.push(b);
+        }
+
+        for b in batches.drain(..9) {
+            deliver(b);
+        }
+        assert_eq!(t.poll_confirmed(), None);
+        assert_eq!(t.confirmed_lsn(), 0);
+
+        deliver(batches.pop().unwrap());
+        assert_eq!(t.poll_confirmed(), Some(200));
+    }
+
+    #[test]
+    fn contiguous_prefix_advancement() {
+        let mut t = LsnTracker::new();
+        let (b100, r100) = new_batch();
+        let (b200, r200) = new_batch();
+        let (b300, r300) = new_batch();
+        t.track(100, r100);
+        t.track(200, r200);
+        t.track(300, r300);
+
+        deliver(b100);
+        deliver(b300);
+
+        assert_eq!(t.poll_confirmed(), Some(100));
+        assert_eq!(t.confirmed_lsn(), 100);
+
+        deliver(b200);
+        assert_eq!(t.poll_confirmed(), Some(300));
+        assert_eq!(t.confirmed_lsn(), 300);
+    }
+
+    #[test]
+    fn dropped_events_advance_lsn() {
+        let mut t = LsnTracker::new();
+        let (b, r) = new_batch();
+        t.track(400, r);
+
+        let f = EventFinalizer::new(b);
+        drop(f);
+
+        assert_eq!(t.poll_confirmed(), Some(400));
+    }
+
+    #[test]
+    fn errored_batch_halts_advancement() {
+        let mut t = LsnTracker::new();
+        let (b1, r1) = new_batch();
+        let (b2, r2) = new_batch();
+        t.track(500, r1);
+        t.track(600, r2);
+
+        errored(b1);
+        deliver(b2);
+
+        assert_eq!(t.poll_confirmed(), None);
+        let (lsn, status) = t.failure().expect("failure recorded");
+        assert_eq!(lsn, 500);
+        assert_eq!(status, BatchStatus::Errored);
+    }
+
+    #[test]
+    fn poll_is_idempotent_when_no_progress() {
+        let mut t = LsnTracker::new();
+        let (_b, r) = new_batch();
+        t.track(700, r);
+
+        assert_eq!(t.poll_confirmed(), None);
+        assert_eq!(t.poll_confirmed(), None);
+        assert_eq!(t.confirmed_lsn(), 0);
+    }
+
+    #[test]
+    fn track_after_partial_advance() {
+        let mut t = LsnTracker::new();
+        let (b100, r100) = new_batch();
+        t.track(100, r100);
+        deliver(b100);
+        assert_eq!(t.poll_confirmed(), Some(100));
+
+        let (b200, r200) = new_batch();
+        t.track(200, r200);
+        deliver(b200);
+        assert_eq!(t.poll_confirmed(), Some(200));
+    }
+
+    // Note: the `TryRecvError::Closed` branch (sender dropped without ever
+    // sending) is unit-testable only by constructing a `BatchStatusReceiver`
+    // whose sender has been dropped, but `BatchNotifier::new_with_receiver`
+    // always sends `Delivered` on Drop, and there is no public test
+    // constructor on `BatchStatusReceiver`. The behaviour is exercised via
+    // the integration suite when a downstream component is reconfigured
+    // mid-stream; see `poll_confirmed` for the (log + treat as delivered)
+    // semantics.
+
+    #[test]
+    fn mark_delivered_immediately_advances_without_receiver() {
+        // The at-most-once code path uses this to keep the slot moving when
+        // E2E acknowledgements are disabled.
+        let mut t = LsnTracker::new();
+        t.mark_delivered_immediately(100);
+        assert_eq!(t.poll_confirmed(), Some(100));
+        assert_eq!(t.confirmed_lsn(), 100);
+    }
+
+    #[test]
+    fn mark_delivered_immediately_is_monotonic() {
+        // Out-of-order calls must never roll the confirmed LSN backwards.
+        let mut t = LsnTracker::new();
+        t.mark_delivered_immediately(200);
+        t.mark_delivered_immediately(100);
+        assert_eq!(t.poll_confirmed(), Some(200));
+    }
+
+    #[test]
+    fn mark_delivered_immediately_blocked_by_failure() {
+        let mut t = LsnTracker::new();
+        let (b, r) = new_batch();
+        t.track(100, r);
+        errored(b);
+        t.poll_confirmed();
+        assert!(t.failure().is_some());
+
+        // Any subsequent attempt to bump the LSN must be ignored.
+        t.mark_delivered_immediately(999);
+        assert_eq!(t.poll_confirmed(), None);
+    }
+
+    #[test]
+    fn is_full_signals_at_cap() {
+        let mut t = LsnTracker::new();
+        // Use mark_delivered_immediately so we don't need to hold thousands
+        // of receivers — but we need entries in `pending` to bump len. So
+        // use track with deliberately-leaked batches for this test.
+        let _held: Vec<BatchNotifier> = (0..10)
+            .map(|i| {
+                let (b, r) = new_batch();
+                t.track(i, r);
+                b
+            })
+            .collect();
+        assert!(!t.is_full());
+        assert_eq!(t.pending_len(), 10);
+    }
+}

--- a/src/sources/postgresql_cdc/mod.rs
+++ b/src/sources/postgresql_cdc/mod.rs
@@ -1,0 +1,16 @@
+//! PostgreSQL logical replication source using the `pgoutput` plugin.
+//!
+//! Streams INSERT / UPDATE / DELETE / TRUNCATE events from a PostgreSQL
+//! database via logical replication. The source requires an existing
+//! publication and replication slot using the `pgoutput` output plugin —
+//! see the configuration documentation for setup instructions.
+
+mod config;
+mod lsn_tracker;
+mod pgoutput;
+mod source;
+
+#[cfg(all(test, feature = "postgresql_cdc-integration-tests"))]
+mod integration_tests;
+
+pub use config::PostgresqlCdcConfig;

--- a/src/sources/postgresql_cdc/pgoutput.rs
+++ b/src/sources/postgresql_cdc/pgoutput.rs
@@ -1,0 +1,1200 @@
+//! pgoutput binary message parser.
+//!
+//! Parses the payload of an `XLogData` CopyData message into row-level events.
+//! pgwire-replication already extracts `Begin` and `Commit` messages and emits
+//! them as separate events, so here we only handle the row-level message
+//! types: `Relation`, `Insert`, `Update`, `Delete`, `Truncate`, `Origin`,
+//! `Type`.
+//!
+//! ## Wire format (`pgoutput`, proto_version = 1)
+//!
+//! Each `XLogData` payload starts with a one-byte message-type tag. The
+//! relevant tags:
+//!
+//! | Tag | Message      | Notes                                            |
+//! |-----|--------------|--------------------------------------------------|
+//! | `R` | Relation     | Schema metadata for a relation OID               |
+//! | `I` | Insert       | New row in a relation                            |
+//! | `U` | Update       | Updated row (and optionally the previous row)    |
+//! | `D` | Delete       | Deleted row (or its key)                         |
+//! | `T` | Truncate     | One or more relations were truncated             |
+//! | `O` | Origin       | Replication origin marker (informational)        |
+//! | `Y` | Type         | Custom type info (informational)                 |
+//!
+//! ## Tuple-data encoding
+//!
+//! Inside Insert/Update/Delete the row is a TupleData block:
+//!
+//! ```text
+//! Int16 num_columns
+//!   per column:
+//!     Int8 kind     'n' = null, 'u' = TOAST unchanged, 't' = text
+//!     if kind == 't':
+//!       Int32 length
+//!       Bytes(length) text-encoded value
+//! ```
+//!
+//! With `proto_version = 1` and the default settings PostgreSQL emits all
+//! column values in TEXT format regardless of the underlying type.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::{Buf, Bytes};
+use chrono::{DateTime, Utc};
+use snafu::Snafu;
+use vector_lib::config::{LegacyKey, LogNamespace};
+use vector_lib::event::{KeyString, LogEvent, ObjectMap, Value};
+use vrl::path;
+
+use crate::sources::postgresql_cdc::config::PostgresqlCdcConfig;
+
+/// Operation kind emitted as the `operation` field on each LogEvent.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Operation {
+    Insert,
+    Update,
+    Delete,
+    Truncate,
+}
+
+impl Operation {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Operation::Insert => "insert",
+            Operation::Update => "update",
+            Operation::Delete => "delete",
+            Operation::Truncate => "truncate",
+        }
+    }
+}
+
+/// Information about a relation, cached by its OID and updated whenever the
+/// server emits a new `Relation` message.
+#[derive(Debug, Clone)]
+struct RelationInfo {
+    schema: Arc<str>,
+    table: Arc<str>,
+    columns: Vec<ColumnInfo>,
+}
+
+#[derive(Debug, Clone)]
+struct ColumnInfo {
+    name: Arc<str>,
+    /// PostgreSQL type OID (e.g. 23 for int4). Used to choose a Vector
+    /// `Value` variant when decoding column text.
+    type_oid: u32,
+    /// `flags & 1 != 0` indicates the column is part of the relation's
+    /// replica-identity key. We keep the raw flags so we can surface this in
+    /// the future if needed; for now it isn't used by the decoder.
+    #[allow(dead_code)]
+    flags: u8,
+}
+
+/// Errors raised while parsing a pgoutput XLogData payload.
+#[derive(Debug, Snafu)]
+pub(super) enum PgoutputError {
+    #[snafu(display("truncated pgoutput message"))]
+    Truncated,
+    #[snafu(display("invalid utf-8 in cstring: {source}"))]
+    InvalidUtf8 { source: std::string::FromUtf8Error },
+    #[snafu(display("unknown relation OID {oid} (Relation message missing before row)"))]
+    UnknownRelation { oid: u32 },
+    #[snafu(display("row message arrived outside of any transaction"))]
+    RowOutsideTransaction,
+    #[snafu(display("tuple data kind byte {kind:?} is not one of 'n' / 'u' / 't'"))]
+    BadTupleKind { kind: u8 },
+    #[snafu(display("UPDATE message tuple-marker byte {kind:?} is not one of 'K' / 'O' / 'N'"))]
+    BadUpdateMarker { kind: u8 },
+    #[snafu(display(
+        "UPDATE message new-tuple marker is {kind:?}; expected 'N' after a 'K'/'O' old tuple"
+    ))]
+    MissingUpdateNewMarker { kind: u8 },
+    #[snafu(display("DELETE message tuple-marker byte {kind:?} is not one of 'K' / 'O'"))]
+    BadDeleteMarker { kind: u8 },
+}
+
+impl From<std::string::FromUtf8Error> for PgoutputError {
+    fn from(source: std::string::FromUtf8Error) -> Self {
+        PgoutputError::InvalidUtf8 { source }
+    }
+}
+
+/// Per-transaction metadata applied to every row event emitted within that
+/// transaction. pgoutput guarantees non-interleaved transaction delivery, so
+/// at most one transaction is open at any time. `Copy` lets the replication
+/// loop snapshot the current transaction's metadata once per XLogData
+/// without re-allocating the `DateTime`.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct TxMeta {
+    pub(super) final_lsn: u64,
+    pub(super) transaction_id: u32,
+    pub(super) commit_timestamp: DateTime<Utc>,
+}
+
+/// One row event produced by parsing a single pgoutput row message.
+#[derive(Debug)]
+pub(super) struct RowEvent {
+    pub(super) log: LogEvent,
+}
+
+/// Outcome of parsing one XLogData payload.
+#[derive(Debug)]
+pub(super) enum Parsed {
+    /// Zero or more row events were produced (Insert/Update/Delete/Truncate).
+    Rows(Vec<RowEvent>),
+    /// The message updated the relation cache or was otherwise informational.
+    NoEvent,
+}
+
+/// pgoutput parser state — owns the relation cache and produces row events.
+pub(super) struct PgoutputParser {
+    relations: HashMap<u32, RelationInfo>,
+}
+
+impl PgoutputParser {
+    pub(super) fn new() -> Self {
+        Self {
+            relations: HashMap::new(),
+        }
+    }
+
+    /// Parses a single XLogData payload into zero or more row events.
+    ///
+    /// `tx_meta` carries the LSN, xid, and commit timestamp from the most
+    /// recent Begin. Row messages outside a transaction return an error.
+    pub(super) fn parse(
+        &mut self,
+        payload: &Bytes,
+        tx_meta: Option<&TxMeta>,
+        log_namespace: LogNamespace,
+    ) -> Result<Parsed, PgoutputError> {
+        let mut buf = payload.as_ref();
+        if buf.is_empty() {
+            return Ok(Parsed::NoEvent);
+        }
+        let tag = read_u8(&mut buf)?;
+        match tag {
+            b'R' => {
+                self.parse_relation(buf)?;
+                Ok(Parsed::NoEvent)
+            }
+            b'I' => {
+                let tx = tx_meta.ok_or(PgoutputError::RowOutsideTransaction)?;
+                let event = self.parse_insert(buf, tx, log_namespace)?;
+                Ok(Parsed::Rows(vec![event]))
+            }
+            b'U' => {
+                let tx = tx_meta.ok_or(PgoutputError::RowOutsideTransaction)?;
+                let event = self.parse_update(buf, tx, log_namespace)?;
+                Ok(Parsed::Rows(vec![event]))
+            }
+            b'D' => {
+                let tx = tx_meta.ok_or(PgoutputError::RowOutsideTransaction)?;
+                let event = self.parse_delete(buf, tx, log_namespace)?;
+                Ok(Parsed::Rows(vec![event]))
+            }
+            b'T' => {
+                let tx = tx_meta.ok_or(PgoutputError::RowOutsideTransaction)?;
+                let events = self.parse_truncate(buf, tx, log_namespace)?;
+                Ok(Parsed::Rows(events))
+            }
+            b'O' | b'Y' => {
+                // Origin and Type messages are informational metadata that
+                // do not carry row data; the row decoder has no use for them.
+                Ok(Parsed::NoEvent)
+            }
+            other => {
+                // Unknown message — log at debug; the upstream caller will see
+                // NoEvent and continue.
+                tracing::debug!(message = "Skipping unknown pgoutput message", tag = ?other);
+                Ok(Parsed::NoEvent)
+            }
+        }
+    }
+
+    fn parse_relation(&mut self, mut buf: &[u8]) -> Result<(), PgoutputError> {
+        let oid = read_u32(&mut buf)?;
+        let schema = read_cstring(&mut buf)?;
+        let table = read_cstring(&mut buf)?;
+        // replica-identity setting — not used directly here, but consume it.
+        let _replica_identity = read_u8(&mut buf)?;
+        let num_columns = read_u16(&mut buf)? as usize;
+        let mut columns = Vec::with_capacity(num_columns);
+        for _ in 0..num_columns {
+            let flags = read_u8(&mut buf)?;
+            let name = read_cstring(&mut buf)?;
+            let type_oid = read_u32(&mut buf)?;
+            // atttypmod — consume but ignore for our purposes.
+            let _atttypmod = read_u32(&mut buf)?;
+            columns.push(ColumnInfo {
+                name: Arc::from(name),
+                type_oid,
+                flags,
+            });
+        }
+        self.relations.insert(
+            oid,
+            RelationInfo {
+                schema: Arc::from(schema),
+                table: Arc::from(table),
+                columns,
+            },
+        );
+        Ok(())
+    }
+
+    fn parse_insert(
+        &self,
+        mut buf: &[u8],
+        tx: &TxMeta,
+        log_namespace: LogNamespace,
+    ) -> Result<RowEvent, PgoutputError> {
+        let oid = read_u32(&mut buf)?;
+        let rel = self
+            .relations
+            .get(&oid)
+            .ok_or(PgoutputError::UnknownRelation { oid })?;
+        // The tuple type byte is always 'N' for Insert; consume it.
+        let _kind = read_u8(&mut buf)?;
+        let (new_obj, toast_omitted) = decode_tuple(&mut buf, rel)?;
+        Ok(build_event(
+            Operation::Insert,
+            rel,
+            tx,
+            Some(new_obj),
+            None,
+            toast_omitted,
+            log_namespace,
+        ))
+    }
+
+    fn parse_update(
+        &self,
+        mut buf: &[u8],
+        tx: &TxMeta,
+        log_namespace: LogNamespace,
+    ) -> Result<RowEvent, PgoutputError> {
+        let oid = read_u32(&mut buf)?;
+        let rel = self
+            .relations
+            .get(&oid)
+            .ok_or(PgoutputError::UnknownRelation { oid })?;
+        // First byte may be 'K' (key-only old tuple), 'O' (full old tuple),
+        // or 'N' (new tuple, no old). 'K'/'O' is followed by an old tuple
+        // and then an 'N' marker before the new tuple; 'N' alone means only
+        // the new tuple follows. Any other byte indicates a server-side
+        // protocol change we do not understand — halt rather than risk
+        // misaligned reads against the rest of the buffer.
+        let kind = read_u8(&mut buf)?;
+        let (old_obj, old_toast) = match kind {
+            b'K' | b'O' => {
+                let (old, t) = decode_tuple(&mut buf, rel)?;
+                let new_marker = read_u8(&mut buf)?;
+                if new_marker != b'N' {
+                    return Err(PgoutputError::MissingUpdateNewMarker { kind: new_marker });
+                }
+                (Some(old), t)
+            }
+            b'N' => (None, Vec::new()),
+            other => return Err(PgoutputError::BadUpdateMarker { kind: other }),
+        };
+        let (new_obj, new_toast) = decode_tuple(&mut buf, rel)?;
+        // Merge TOAST-omitted lists; columns may differ between old and new.
+        let mut toast_omitted = old_toast;
+        for col in new_toast {
+            if !toast_omitted.contains(&col) {
+                toast_omitted.push(col);
+            }
+        }
+        Ok(build_event(
+            Operation::Update,
+            rel,
+            tx,
+            Some(new_obj),
+            old_obj,
+            toast_omitted,
+            log_namespace,
+        ))
+    }
+
+    fn parse_delete(
+        &self,
+        mut buf: &[u8],
+        tx: &TxMeta,
+        log_namespace: LogNamespace,
+    ) -> Result<RowEvent, PgoutputError> {
+        let oid = read_u32(&mut buf)?;
+        let rel = self
+            .relations
+            .get(&oid)
+            .ok_or(PgoutputError::UnknownRelation { oid })?;
+        // 'K' = key-only old tuple, 'O' = full old tuple (depending on
+        // REPLICA IDENTITY). Any other byte indicates a server-side protocol
+        // change; halt rather than risk misaligned reads.
+        let kind = read_u8(&mut buf)?;
+        if kind != b'K' && kind != b'O' {
+            return Err(PgoutputError::BadDeleteMarker { kind });
+        }
+        let (old_obj, toast_omitted) = decode_tuple(&mut buf, rel)?;
+        Ok(build_event(
+            Operation::Delete,
+            rel,
+            tx,
+            None,
+            Some(old_obj),
+            toast_omitted,
+            log_namespace,
+        ))
+    }
+
+    fn parse_truncate(
+        &self,
+        mut buf: &[u8],
+        tx: &TxMeta,
+        log_namespace: LogNamespace,
+    ) -> Result<Vec<RowEvent>, PgoutputError> {
+        let num_relations = read_u32(&mut buf)? as usize;
+        // option flags (CASCADE / RESTART IDENTITY) — consume.
+        let _flags = read_u8(&mut buf)?;
+        let mut events = Vec::with_capacity(num_relations);
+        for _ in 0..num_relations {
+            let oid = read_u32(&mut buf)?;
+            // Unknown-OID handling for TRUNCATE deliberately differs from
+            // INSERT/UPDATE/DELETE: a TRUNCATE message bundles many
+            // relations in a single payload, and skipping an unknown one
+            // still lets us emit events for the known relations in the same
+            // batch. INSERT/UPDATE/DELETE carry only one relation each and
+            // cannot recover from a missing schema mapping, so they halt
+            // with `UnknownRelation`. The mismatch is intentional.
+            let rel = match self.relations.get(&oid) {
+                Some(rel) => rel,
+                None => {
+                    tracing::debug!(message = "TRUNCATE on unknown relation OID", oid = oid);
+                    continue;
+                }
+            };
+            events.push(build_event(
+                Operation::Truncate,
+                rel,
+                tx,
+                None,
+                None,
+                Vec::new(),
+                log_namespace,
+            ));
+        }
+        Ok(events)
+    }
+}
+
+/// Builds a LogEvent from the pieces produced by row-level parsing.
+///
+/// Field placement honours `log_namespace`: under `Legacy` every field
+/// lands at the root of the `LogEvent` (the original shape); under
+/// `Vector` every field lands under `%postgresql_cdc.<field>` event
+/// metadata. The `LegacyKey::Overwrite` calls below intentionally mirror
+/// the pre-namespace insertion behaviour for backwards compatibility.
+fn build_event(
+    operation: Operation,
+    rel: &RelationInfo,
+    tx: &TxMeta,
+    new: Option<ObjectMap>,
+    old: Option<ObjectMap>,
+    toast_omitted: Vec<Arc<str>>,
+    log_namespace: LogNamespace,
+) -> RowEvent {
+    let mut log = LogEvent::default();
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("operation"))),
+        path!("operation"),
+        operation.as_str(),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("schema"))),
+        path!("schema"),
+        Value::from(rel.schema.as_ref()),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("table"))),
+        path!("table"),
+        Value::from(rel.table.as_ref()),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("lsn"))),
+        path!("lsn"),
+        format_lsn(tx.final_lsn),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("transaction_id"))),
+        path!("transaction_id"),
+        Value::Integer(i64::from(tx.transaction_id)),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("transaction_timestamp"))),
+        path!("transaction_timestamp"),
+        Value::from(tx.commit_timestamp),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("new"))),
+        path!("new"),
+        new.map(Value::Object).unwrap_or(Value::Null),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("old"))),
+        path!("old"),
+        old.map(Value::Object).unwrap_or(Value::Null),
+    );
+    if !toast_omitted.is_empty() {
+        let omitted: Vec<Value> = toast_omitted
+            .into_iter()
+            .map(|s| Value::from(s.as_ref()))
+            .collect();
+        log_namespace.insert_source_metadata(
+            PostgresqlCdcConfig::NAME,
+            &mut log,
+            Some(LegacyKey::Overwrite(path!("__toast_omitted"))),
+            path!("toast_omitted"),
+            Value::Array(omitted),
+        );
+    }
+    log_namespace.insert_standard_vector_source_metadata(
+        &mut log,
+        PostgresqlCdcConfig::NAME,
+        Utc::now(),
+    );
+    RowEvent { log }
+}
+
+/// Decodes a tuple-data block, returning the object map of column values plus
+/// the list of columns omitted as `UnchangedToastDatum`. Column names are
+/// `Arc<str>` references into the `RelationInfo` cache — no heap allocation
+/// per column per row.
+fn decode_tuple(
+    buf: &mut &[u8],
+    rel: &RelationInfo,
+) -> Result<(ObjectMap, Vec<Arc<str>>), PgoutputError> {
+    let num_columns = read_u16(buf)? as usize;
+    let mut obj = ObjectMap::new();
+    let mut toast_omitted = Vec::new();
+    for i in 0..num_columns {
+        let kind = read_u8(buf)?;
+        let col = rel.columns.get(i);
+        match kind {
+            b'n' => {
+                if let Some(col) = col {
+                    obj.insert(KeyString::from(col.name.as_ref()), Value::Null);
+                }
+            }
+            b'u' => {
+                if let Some(col) = col {
+                    toast_omitted.push(Arc::clone(&col.name));
+                }
+            }
+            b't' => {
+                let len = read_u32(buf)? as usize;
+                if buf.len() < len {
+                    return Err(PgoutputError::Truncated);
+                }
+                let (value_bytes, rest) = buf.split_at(len);
+                let value_bytes = value_bytes.to_vec();
+                *buf = rest;
+                if let Some(col) = col {
+                    let value = decode_value(col.type_oid, value_bytes);
+                    obj.insert(KeyString::from(col.name.as_ref()), value);
+                }
+            }
+            other => return Err(PgoutputError::BadTupleKind { kind: other }),
+        }
+    }
+    Ok((obj, toast_omitted))
+}
+
+/// Maps a column's raw TEXT-format bytes to a Vector `Value` based on the
+/// column's PostgreSQL type OID.
+///
+/// Type mapping:
+/// - text/varchar/char/name → `Value::Bytes`
+/// - int2/int4/int8 → `Value::Integer`
+/// - float4/float8 → `Value::Float`
+/// - numeric → `Value::Bytes` (preserve exact precision; do NOT cast to f64)
+/// - bool → `Value::Boolean`
+/// - bytea → `Value::Bytes` of the decoded raw bytes
+/// - json/jsonb → `Value::Object` (parsed)
+/// - date/timestamp/timestamptz → `Value::Bytes` (ISO8601)
+/// - other → `Value::Bytes`
+fn decode_value(type_oid: u32, bytes: Vec<u8>) -> Value {
+    // Postgres type OIDs that are stable in src/include/catalog/pg_type.dat.
+    const BOOL: u32 = 16;
+    const BYTEA: u32 = 17;
+    const NAME: u32 = 19;
+    const INT8: u32 = 20;
+    const INT2: u32 = 21;
+    const INT4: u32 = 23;
+    const TEXT: u32 = 25;
+    const JSON: u32 = 114;
+    const FLOAT4: u32 = 700;
+    const FLOAT8: u32 = 701;
+    const BPCHAR: u32 = 1042;
+    const VARCHAR: u32 = 1043;
+    const NUMERIC: u32 = 1700;
+    const JSONB: u32 = 3802;
+
+    match type_oid {
+        BOOL => match bytes.as_slice() {
+            b"t" => Value::Boolean(true),
+            b"f" => Value::Boolean(false),
+            _ => Value::Bytes(bytes.into()),
+        },
+        INT2 | INT4 | INT8 => parse_integer(&bytes).unwrap_or_else(|| Value::Bytes(bytes.into())),
+        FLOAT4 | FLOAT8 => parse_float(&bytes).unwrap_or_else(|| Value::Bytes(bytes.into())),
+        BYTEA => Value::Bytes(decode_bytea(&bytes).into()),
+        JSON | JSONB => parse_json(&bytes).unwrap_or_else(|| Value::Bytes(bytes.into())),
+        // NUMERIC, TEXT-like, dates/timestamps, and everything else stay as
+        // Bytes — VRL transforms can refine downstream.
+        NUMERIC | TEXT | VARCHAR | BPCHAR | NAME => Value::Bytes(bytes.into()),
+        _ => Value::Bytes(bytes.into()),
+    }
+}
+
+fn parse_integer(bytes: &[u8]) -> Option<Value> {
+    let s = std::str::from_utf8(bytes).ok()?;
+    s.parse::<i64>().ok().map(Value::Integer)
+}
+
+fn parse_float(bytes: &[u8]) -> Option<Value> {
+    let s = std::str::from_utf8(bytes).ok()?;
+    let parsed = s.parse::<f64>().ok()?;
+    // Reject both NaN and ±Infinity. NaN is forbidden by `Value::Float`'s
+    // `NotNan` wrapper; Infinity is technically representable but downstream
+    // JSON-based sinks cannot encode it cleanly. Falling back to the raw
+    // text gives consumers a string they can pattern-match deterministically.
+    if !parsed.is_finite() {
+        return None;
+    }
+    ordered_float::NotNan::new(parsed).ok().map(Value::Float)
+}
+
+fn parse_json(bytes: &[u8]) -> Option<Value> {
+    let parsed: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    Some(Value::from(parsed))
+}
+
+/// Decodes Postgres' default text-format bytea representation.
+///
+/// Modern Postgres defaults to `\x...` hex encoding, which is decoded to
+/// raw bytes. Legacy escape format (`\\NNN` octal escapes) is passed through
+/// unchanged; users on legacy configurations can decode in a VRL transform.
+/// Anything that fails to decode is returned as-is so the user can still
+/// see the raw bytes.
+fn decode_bytea(bytes: &[u8]) -> Vec<u8> {
+    if bytes.starts_with(b"\\x") {
+        // Hex format: \x<hex...>. Odd-length hex is malformed (PG never
+        // emits it) — fall back to the raw escape so the user sees the
+        // corruption directly rather than silently losing the trailing
+        // nibble.
+        let hex = &bytes[2..];
+        if !hex.len().is_multiple_of(2) {
+            return bytes.to_vec();
+        }
+        let mut out = Vec::with_capacity(hex.len() / 2);
+        let mut iter = hex.iter().copied();
+        while let (Some(h), Some(l)) = (iter.next(), iter.next()) {
+            match (hex_digit(h), hex_digit(l)) {
+                (Some(h), Some(l)) => out.push((h << 4) | l),
+                _ => return bytes.to_vec(),
+            }
+        }
+        out
+    } else {
+        // Escape format — pass through unchanged. Users on legacy
+        // configurations can decode in a VRL transform if needed.
+        bytes.to_vec()
+    }
+}
+
+const fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Formats an LSN as Postgres' `X/Y` uppercase-hex representation.
+pub(super) fn format_lsn(lsn: u64) -> String {
+    let hi = (lsn >> 32) as u32;
+    let lo = (lsn & 0xFFFF_FFFF) as u32;
+    format!("{:X}/{:X}", hi, lo)
+}
+
+// --- Low-level binary readers ---------------------------------------------
+
+fn read_u8(buf: &mut &[u8]) -> Result<u8, PgoutputError> {
+    if buf.is_empty() {
+        return Err(PgoutputError::Truncated);
+    }
+    let v = buf[0];
+    *buf = &buf[1..];
+    Ok(v)
+}
+
+fn read_u16(buf: &mut &[u8]) -> Result<u16, PgoutputError> {
+    if buf.len() < 2 {
+        return Err(PgoutputError::Truncated);
+    }
+    let v = (&buf[..2]).get_u16();
+    *buf = &buf[2..];
+    Ok(v)
+}
+
+fn read_u32(buf: &mut &[u8]) -> Result<u32, PgoutputError> {
+    if buf.len() < 4 {
+        return Err(PgoutputError::Truncated);
+    }
+    let v = (&buf[..4]).get_u32();
+    *buf = &buf[4..];
+    Ok(v)
+}
+
+fn read_cstring(buf: &mut &[u8]) -> Result<String, PgoutputError> {
+    let pos = buf
+        .iter()
+        .position(|&b| b == 0)
+        .ok_or(PgoutputError::Truncated)?;
+    let s = String::from_utf8(buf[..pos].to_vec())?;
+    *buf = &buf[pos + 1..];
+    Ok(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn tx_meta() -> TxMeta {
+        TxMeta {
+            final_lsn: 0x1_2345_6789,
+            transaction_id: 42,
+            commit_timestamp: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        }
+    }
+
+    /// Builds a minimal Relation message for `public.users(id int4, name text)`.
+    fn relation_bytes() -> Bytes {
+        let mut b = Vec::new();
+        b.push(b'R');
+        b.extend_from_slice(&100u32.to_be_bytes()); // OID
+        b.extend_from_slice(b"public\0");
+        b.extend_from_slice(b"users\0");
+        b.push(b'd'); // replica identity = default
+        b.extend_from_slice(&2u16.to_be_bytes()); // 2 columns
+        // id int4 NOT NULL (flags=1 = key)
+        b.push(1);
+        b.extend_from_slice(b"id\0");
+        b.extend_from_slice(&23u32.to_be_bytes()); // int4
+        b.extend_from_slice(&u32::MAX.to_be_bytes()); // atttypmod
+        // name text
+        b.push(0);
+        b.extend_from_slice(b"name\0");
+        b.extend_from_slice(&25u32.to_be_bytes()); // text
+        b.extend_from_slice(&u32::MAX.to_be_bytes());
+        Bytes::from(b)
+    }
+
+    fn insert_bytes() -> Bytes {
+        let mut b = Vec::new();
+        b.push(b'I');
+        b.extend_from_slice(&100u32.to_be_bytes()); // OID
+        b.push(b'N');
+        b.extend_from_slice(&2u16.to_be_bytes()); // 2 columns
+        // id = 42
+        b.push(b't');
+        b.extend_from_slice(&2u32.to_be_bytes());
+        b.extend_from_slice(b"42");
+        // name = 'alice'
+        b.push(b't');
+        b.extend_from_slice(&5u32.to_be_bytes());
+        b.extend_from_slice(b"alice");
+        Bytes::from(b)
+    }
+
+    #[test]
+    fn insert_in_vector_namespace_places_fields_under_metadata() {
+        // Under the Vector log namespace, every CDC field must land under
+        // `%postgresql_cdc.<field>` event metadata rather than at the root
+        // of the LogEvent. This locks the namespace plumbing in place — a
+        // regression that bypasses `insert_source_metadata` would put the
+        // fields back at the root and break schema validators that expect
+        // the Vector-namespace shape.
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Vector)
+            .unwrap();
+        let parsed = p
+            .parse(&insert_bytes(), Some(&tx), LogNamespace::Vector)
+            .unwrap();
+        let log = match parsed {
+            Parsed::Rows(events) => events.into_iter().next().unwrap().log,
+            Parsed::NoEvent => panic!("expected row event"),
+        };
+
+        // Root must NOT contain the CDC fields under Vector namespace.
+        assert!(log.get("operation").is_none(), "operation leaked to root");
+        assert!(log.get("new").is_none(), "new leaked to root");
+        assert!(log.get("schema").is_none(), "schema leaked to root");
+
+        // They must be present under %postgresql_cdc.<field>.
+        let meta = log.metadata().value();
+        assert_eq!(
+            meta.get(path!("postgresql_cdc", "operation")).unwrap(),
+            &Value::from("insert")
+        );
+        assert_eq!(
+            meta.get(path!("postgresql_cdc", "schema")).unwrap(),
+            &Value::from("public")
+        );
+        assert_eq!(
+            meta.get(path!("postgresql_cdc", "table")).unwrap(),
+            &Value::from("users")
+        );
+        match meta.get(path!("postgresql_cdc", "new")).unwrap() {
+            Value::Object(map) => {
+                assert_eq!(map.get("id").unwrap(), &Value::Integer(42));
+                assert_eq!(map.get("name").unwrap(), &Value::from("alice"));
+            }
+            other => panic!("expected `new` Object under metadata, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relation_then_insert() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        assert!(matches!(
+            p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+                .unwrap(),
+            Parsed::NoEvent
+        ));
+        let parsed = p
+            .parse(&insert_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        match parsed {
+            Parsed::Rows(events) => {
+                assert_eq!(events.len(), 1);
+                let log = &events[0].log;
+                assert_eq!(log.get("operation").unwrap(), &Value::from("insert"));
+                assert_eq!(log.get("schema").unwrap(), &Value::from("public"));
+                assert_eq!(log.get("table").unwrap(), &Value::from("users"));
+                assert_eq!(log.get("transaction_id").unwrap(), &Value::Integer(42));
+                assert_eq!(
+                    log.get("lsn").unwrap(),
+                    &Value::from(format_lsn(0x1_2345_6789))
+                );
+                let new = log.get("new").unwrap();
+                match new {
+                    Value::Object(map) => {
+                        assert_eq!(map.get("id").unwrap(), &Value::Integer(42));
+                        assert_eq!(map.get("name").unwrap(), &Value::from("alice"));
+                    }
+                    _ => panic!("expected Object for 'new'"),
+                }
+                assert_eq!(log.get("old").unwrap(), &Value::Null);
+            }
+            Parsed::NoEvent => panic!("expected row event"),
+        }
+    }
+
+    #[test]
+    fn insert_without_relation_errors() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        let result = p.parse(&insert_bytes(), Some(&tx), LogNamespace::Legacy);
+        assert!(matches!(
+            result,
+            Err(PgoutputError::UnknownRelation { oid: 100 })
+        ));
+    }
+
+    #[test]
+    fn row_outside_tx_errors() {
+        let mut p = PgoutputParser::new();
+        p.parse(&relation_bytes(), None, LogNamespace::Legacy)
+            .unwrap();
+        let result = p.parse(&insert_bytes(), None, LogNamespace::Legacy);
+        assert!(matches!(result, Err(PgoutputError::RowOutsideTransaction)));
+    }
+
+    #[test]
+    fn update_with_unknown_marker_errors() {
+        // Per pgoutput spec the first marker byte must be 'K', 'O', or 'N'.
+        // A different byte indicates a server-side protocol change we do not
+        // understand — halt rather than risk a misaligned read.
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        let mut b = Vec::new();
+        b.push(b'U');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'X'); // bogus marker
+        let result = p.parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy);
+        assert!(
+            matches!(result, Err(PgoutputError::BadUpdateMarker { kind: b'X' })),
+            "expected BadUpdateMarker, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn update_missing_new_marker_after_key_errors() {
+        // After a 'K' (or 'O') old tuple, the next byte MUST be 'N' before
+        // the new tuple. A non-'N' byte means we have misread the payload
+        // or the server emitted an unsupported form — halt cleanly.
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        let mut b = Vec::new();
+        b.push(b'U');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'K'); // key-only old tuple
+        // Minimal old tuple: 2 columns, id=1, name=NULL.
+        b.extend_from_slice(&2u16.to_be_bytes());
+        b.push(b't');
+        b.extend_from_slice(&1u32.to_be_bytes());
+        b.push(b'1');
+        b.push(b'n');
+        b.push(b'X'); // bogus new-marker (should be 'N')
+        let result = p.parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy);
+        assert!(
+            matches!(
+                result,
+                Err(PgoutputError::MissingUpdateNewMarker { kind: b'X' })
+            ),
+            "expected MissingUpdateNewMarker, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn delete_with_unknown_marker_errors() {
+        // DELETE message tuple-marker must be 'K' or 'O'.
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        let mut b = Vec::new();
+        b.push(b'D');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'Z'); // bogus
+        let result = p.parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy);
+        assert!(
+            matches!(result, Err(PgoutputError::BadDeleteMarker { kind: b'Z' })),
+            "expected BadDeleteMarker, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn null_column_is_value_null() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        let mut b = Vec::new();
+        b.push(b'I');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'N');
+        b.extend_from_slice(&2u16.to_be_bytes());
+        b.push(b't');
+        b.extend_from_slice(&1u32.to_be_bytes());
+        b.push(b'7');
+        b.push(b'n'); // NULL
+        let payload = Bytes::from(b);
+        let parsed = p.parse(&payload, Some(&tx), LogNamespace::Legacy).unwrap();
+        match parsed {
+            Parsed::Rows(events) => match events[0].log.get("new").unwrap() {
+                Value::Object(map) => {
+                    assert_eq!(map.get("id").unwrap(), &Value::Integer(7));
+                    assert_eq!(map.get("name").unwrap(), &Value::Null);
+                }
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn toast_unchanged_omits_column() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        let mut b = Vec::new();
+        b.push(b'I');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'N');
+        b.extend_from_slice(&2u16.to_be_bytes());
+        b.push(b't');
+        b.extend_from_slice(&1u32.to_be_bytes());
+        b.push(b'7');
+        b.push(b'u'); // TOAST unchanged
+        let payload = Bytes::from(b);
+        let parsed = p.parse(&payload, Some(&tx), LogNamespace::Legacy).unwrap();
+        match parsed {
+            Parsed::Rows(events) => {
+                let log = &events[0].log;
+                let omitted = log.get("__toast_omitted").unwrap();
+                match omitted {
+                    Value::Array(arr) => {
+                        assert_eq!(arr.len(), 1);
+                        assert_eq!(arr[0], Value::from("name"));
+                    }
+                    _ => panic!(),
+                }
+                let new = log.get("new").unwrap();
+                if let Value::Object(map) = new {
+                    assert!(!map.contains_key("name"));
+                } else {
+                    panic!();
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn schema_change_invalidates_relation_cache() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+
+        // New Relation: same OID, now with an extra column.
+        let mut b = Vec::new();
+        b.push(b'R');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.extend_from_slice(b"public\0");
+        b.extend_from_slice(b"users\0");
+        b.push(b'd');
+        b.extend_from_slice(&3u16.to_be_bytes());
+        b.push(1);
+        b.extend_from_slice(b"id\0");
+        b.extend_from_slice(&23u32.to_be_bytes());
+        b.extend_from_slice(&u32::MAX.to_be_bytes());
+        b.push(0);
+        b.extend_from_slice(b"name\0");
+        b.extend_from_slice(&25u32.to_be_bytes());
+        b.extend_from_slice(&u32::MAX.to_be_bytes());
+        b.push(0);
+        b.extend_from_slice(b"email\0");
+        b.extend_from_slice(&25u32.to_be_bytes());
+        b.extend_from_slice(&u32::MAX.to_be_bytes());
+        p.parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+
+        // Insert that includes the new column.
+        let mut b = Vec::new();
+        b.push(b'I');
+        b.extend_from_slice(&100u32.to_be_bytes());
+        b.push(b'N');
+        b.extend_from_slice(&3u16.to_be_bytes());
+        b.push(b't');
+        b.extend_from_slice(&1u32.to_be_bytes());
+        b.push(b'9');
+        b.push(b't');
+        b.extend_from_slice(&3u32.to_be_bytes());
+        b.extend_from_slice(b"bob");
+        b.push(b't');
+        b.extend_from_slice(&5u32.to_be_bytes());
+        b.extend_from_slice(b"b@b.c");
+        let parsed = p
+            .parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        match parsed {
+            Parsed::Rows(events) => {
+                if let Value::Object(map) = events[0].log.get("new").unwrap() {
+                    assert_eq!(map.get("email").unwrap(), &Value::from("b@b.c"));
+                } else {
+                    panic!();
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn truncate_emits_one_event_per_relation() {
+        let mut p = PgoutputParser::new();
+        let tx = tx_meta();
+        p.parse(&relation_bytes(), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+
+        let mut b = Vec::new();
+        b.push(b'T');
+        b.extend_from_slice(&1u32.to_be_bytes()); // 1 relation
+        b.push(0); // no flags
+        b.extend_from_slice(&100u32.to_be_bytes());
+        let parsed = p
+            .parse(&Bytes::from(b), Some(&tx), LogNamespace::Legacy)
+            .unwrap();
+        match parsed {
+            Parsed::Rows(events) => {
+                assert_eq!(events.len(), 1);
+                let log = &events[0].log;
+                assert_eq!(log.get("operation").unwrap(), &Value::from("truncate"));
+                assert_eq!(log.get("table").unwrap(), &Value::from("users"));
+                assert_eq!(log.get("new").unwrap(), &Value::Null);
+                assert_eq!(log.get("old").unwrap(), &Value::Null);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn format_lsn_matches_postgres_display() {
+        assert_eq!(format_lsn(0), "0/0");
+        assert_eq!(format_lsn(0x16_B374_D848), "16/B374D848");
+        assert_eq!(format_lsn(0xFFFF_FFFF_FFFF_FFFF), "FFFFFFFF/FFFFFFFF");
+        // High part non-zero, low part zero — bit-shift sanity check.
+        assert_eq!(format_lsn(0x1_0000_0000), "1/0");
+    }
+
+    // ---- decode_value table tests ---------------------------------------
+    //
+    // The wire-format text representation Postgres sends for each type is
+    // pinned here. A regression in the OID branches of `decode_value` would
+    // silently change the type of a user's column under them; these unit
+    // tests catch that in milliseconds, without needing a Postgres instance.
+
+    fn decode(oid: u32, bytes: &[u8]) -> Value {
+        decode_value(oid, bytes.to_vec())
+    }
+
+    #[test]
+    fn decode_value_bool() {
+        assert_eq!(decode(16, b"t"), Value::Boolean(true));
+        assert_eq!(decode(16, b"f"), Value::Boolean(false));
+        // Anything other than "t"/"f" falls back to Bytes (PG would never
+        // send this, but the fallback must be safe).
+        assert_eq!(decode(16, b"yes"), Value::Bytes("yes".into()));
+    }
+
+    #[test]
+    fn decode_value_integers() {
+        assert_eq!(decode(21, b"42"), Value::Integer(42)); // int2
+        assert_eq!(decode(23, b"-1"), Value::Integer(-1)); // int4
+        assert_eq!(decode(20, b"9223372036854775807"), Value::Integer(i64::MAX)); // int8
+        // Out-of-i64-range: fall back to Bytes preserving the exact value.
+        assert_eq!(
+            decode(20, b"9223372036854775808"),
+            Value::Bytes("9223372036854775808".into())
+        );
+    }
+
+    #[test]
+    fn decode_value_floats() {
+        match decode(700, b"3.14") {
+            Value::Float(f) => assert!((f.into_inner() - 3.14).abs() < 1e-9),
+            other => panic!("expected Float, got {other:?}"),
+        }
+        match decode(701, b"-0.5") {
+            Value::Float(f) => assert!((f.into_inner() + 0.5).abs() < 1e-9),
+            other => panic!("expected Float, got {other:?}"),
+        }
+        // NaN and Inf both fail NotNan::new and fall back to Bytes.
+        assert_eq!(decode(701, b"NaN"), Value::Bytes("NaN".into()));
+        assert_eq!(decode(701, b"Infinity"), Value::Bytes("Infinity".into()));
+    }
+
+    #[test]
+    fn decode_value_numeric_preserved_exactly() {
+        // The defining numeric property: arbitrary precision survives the
+        // round-trip. Tests cover typical currency precision as well as
+        // values f64 cannot represent exactly.
+        for &s in &[
+            "0",
+            "1.00",
+            "9999999999.9999",        // 14-digit currency
+            "1.234567890123456789",   // 19 significant digits
+            "-0.0001",                // sub-cent precision
+            "12345678901234567890.5", // 21 digits — exceeds i64 and f64 mantissa
+        ] {
+            assert_eq!(decode(1700, s.as_bytes()), Value::Bytes(s.into()));
+        }
+    }
+
+    #[test]
+    fn decode_value_text_types() {
+        for oid in [25, 1043, 1042, 19] {
+            assert_eq!(decode(oid, b"hello"), Value::Bytes("hello".into()));
+        }
+        // UTF-8 multi-byte string in a text column.
+        assert_eq!(
+            decode(25, "héllo 世界".as_bytes()),
+            Value::Bytes("héllo 世界".into())
+        );
+    }
+
+    #[test]
+    fn decode_value_bytea_hex() {
+        // PG default: `\x` followed by hex.
+        let bytea = b"\\xdeadbeef";
+        match decode(17, bytea) {
+            Value::Bytes(b) => assert_eq!(&b[..], &[0xDE, 0xAD, 0xBE, 0xEF][..]),
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+        // Empty hex.
+        match decode(17, b"\\x") {
+            Value::Bytes(b) => assert!(b.is_empty()),
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+        // Odd-length hex falls back to the raw bytes (defensible — PG would
+        // never emit this, but we must not silently truncate).
+        match decode(17, b"\\xabc") {
+            Value::Bytes(b) => assert_eq!(&b[..], b"\\xabc"),
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_value_json_and_jsonb() {
+        for &oid in &[114u32, 3802] {
+            let v = decode(oid, br#"{"id":42,"name":"alice"}"#);
+            match v {
+                Value::Object(map) => {
+                    assert_eq!(map.get("id").unwrap(), &Value::Integer(42));
+                    assert_eq!(map.get("name").unwrap(), &Value::from("alice"));
+                }
+                other => panic!("expected Object, got {other:?}"),
+            }
+        }
+        // Malformed JSON falls back to the raw text.
+        let v = decode(114, b"not json");
+        assert_eq!(v, Value::Bytes("not json".into()));
+    }
+
+    #[test]
+    fn decode_value_unknown_oid_falls_back_to_bytes() {
+        // Any OID we don't special-case stays as opaque text. This is the
+        // contract for UUID, inet, cidr, timestamps, intervals, ranges, etc.
+        for oid in [2950u32, 869, 1184, 1186, 3904] {
+            assert_eq!(decode(oid, b"opaque"), Value::Bytes("opaque".into()));
+        }
+    }
+}

--- a/src/sources/postgresql_cdc/source.rs
+++ b/src/sources/postgresql_cdc/source.rs
@@ -1,0 +1,878 @@
+//! Async replication loop for the `postgresql_cdc` source.
+//!
+//! ## Overview
+//!
+//! 1. **Setup connection** (`tokio_postgres`, non-replication) — validates
+//!    that the configured slot exists, uses the `pgoutput` plugin, is not
+//!    already attached to another consumer, and has WAL still retained. The
+//!    connection honours the same TLS configuration as the replication
+//!    connection; it would be a security regression to send the password
+//!    cleartext while validating and then upgrade later.
+//!
+//! 2. **Replication client** (`pgwire_replication`) — opens a logical
+//!    replication connection and streams events. pgwire handles framing,
+//!    keepalives, and standby status updates internally; we feed it the
+//!    confirmed LSN via [`ReplicationClient::update_applied_lsn`].
+//!
+//! 3. **Event loop** — receives [`ReplicationEvent`]s, maintains the current
+//!    transaction's metadata, parses pgoutput row messages, attaches a
+//!    [`BatchNotifier`] to each emitted event (when acknowledgements are
+//!    enabled), and registers the resulting receiver with the
+//!    [`LsnTracker`]. After each iteration the tracker is polled
+//!    non-blockingly; when the confirmed LSN advances it is forwarded to the
+//!    replication client.
+//!
+//! ## Security: password handling
+//!
+//! The libpq password lives temporarily in a `String` on the
+//! [`pgwire_replication::ReplicationConfig`] we construct. That type derives
+//! `Debug` and does not redact the password (see
+//! [`build_replication_config`] for the safety contract). **Never** format
+//! the resulting config with `{:?}` or `?cfg` anywhere — only debug-format
+//! the public-safe fields (host, user, database).
+
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use pgwire_replication::{
+    Lsn, ReplicationClient, ReplicationEvent,
+    config::{ReplicationConfig as PgwireConfig, SslMode, TlsConfig as PgwireTlsConfig},
+};
+use postgres_openssl::MakeTlsConnector;
+use snafu::Snafu;
+use tokio::time::sleep;
+use tokio_postgres::NoTls;
+use vector_lib::{
+    config::LogNamespace,
+    event::{BatchNotifier, BatchStatusReceiver, Event, LogEvent, Value},
+    shutdown::ShutdownSignal,
+};
+
+use vector_lib::{
+    EstimatedJsonEncodedSizeOf,
+    internal_event::{
+        BytesReceived, CountByteSize, EventsReceived, InternalEventHandle as _, Protocol,
+        Registered,
+    },
+};
+
+use super::{
+    config::{PostgresqlCdcConfig, PostgresqlCdcTlsConfig},
+    lsn_tracker::LsnTracker,
+    pgoutput::{Parsed, PgoutputParser, TxMeta, format_lsn},
+};
+use crate::{
+    SourceSender,
+    internal_events::{
+        PostgresqlCdcParseError, PostgresqlCdcProtocolViolation, PostgresqlCdcReplicationError,
+        PostgresqlCdcSinkAckFailed, StreamClosedError,
+    },
+};
+
+/// Microseconds from the Unix epoch (1970-01-01) to the PostgreSQL epoch
+/// (2000-01-01). Add this to a PG-epoch micros value to get Unix-epoch micros.
+const PG_EPOCH_OFFSET_MICROS: i64 = 946_684_800_000_000;
+
+/// Maximum time the event loop blocks waiting on `client.recv()` before
+/// polling the LSN tracker. This bounds how late a confirmed-flush update
+/// is reported when the stream is otherwise idle.
+///
+/// **Derivation:** the lower bound is CPU cost of a `try_recv` poll loop
+/// (negligible — no syscall, just an atomic load per pending LSN). The
+/// upper bound is how much "extra" WAL PostgreSQL retains after a sink
+/// ack lands but before we forward the new confirmed LSN: at 250ms the
+/// server holds at most one quarter-second of already-consumed WAL,
+/// which is insignificant relative to typical `wal_keep_size` budgets
+/// (often GB-scale). Values in the 100ms–1s range are all reasonable;
+/// 250ms was chosen as a middle ground. See the `postgresql_cdc-benchmarks`
+/// feature for throughput tests at different intervals.
+const TRACKER_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Cadence at which `pgwire-replication` sends a `StandbyStatusUpdate` to
+/// the server.
+///
+/// **Derivation:** PostgreSQL's `wal_sender_timeout` (default 60s) kills
+/// the replication connection if it sees no client activity for that long.
+/// The status update must fire well under half that threshold (~30s) to
+/// avoid spurious disconnects. `pgwire-replication`'s own default is 10s,
+/// which is safe but means `confirmed_flush_lsn` only advances every 10s
+/// even when the sink acks sub-second — making slot-lag dashboards look
+/// stale. 500ms gives 120× safety margin against the 60s timeout while
+/// providing near-real-time progress reporting. Values from 250ms to 2s
+/// are all viable; the throughput difference is negligible because the
+/// status update is a single 34-byte `StandbyStatusUpdate` message.
+const STATUS_UPDATE_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Snafu)]
+pub(super) enum BuildError {
+    #[snafu(display("invalid connection_string: {source}"))]
+    InvalidConnectionString { source: tokio_postgres::Error },
+    #[snafu(display(
+        "connection_string is missing the {field} component required for replication"
+    ))]
+    MissingConnectionField { field: &'static str },
+    #[snafu(display(
+        "password contains non-UTF-8 bytes; pgwire-replication requires a UTF-8 password"
+    ))]
+    NonUtf8Password,
+    #[snafu(display("failed to build TLS connector: {message}"))]
+    TlsBuild { message: String },
+    #[snafu(display("failed to open setup connection: {source}"))]
+    SetupConnect { source: tokio_postgres::Error },
+    #[snafu(display(
+        "replication slot {slot:?} does not exist on the server; create it with \
+         SELECT pg_create_logical_replication_slot({slot:?}, 'pgoutput') before running this source"
+    ))]
+    SlotMissing { slot: String },
+    #[snafu(display(
+        "replication slot {slot:?} uses output_plugin={plugin:?}, but only 'pgoutput' is supported"
+    ))]
+    WrongOutputPlugin { slot: String, plugin: String },
+    #[snafu(display(
+        "replication slot {slot:?} is currently attached to another consumer (active=true). \
+         Stop the other consumer or wait for it to disconnect before starting this source."
+    ))]
+    SlotAlreadyActive { slot: String },
+    #[snafu(display(
+        "replication slot {slot:?} reports wal_status={status:?}; the WAL required to resume \
+         this slot has been removed by the server. Recreate the slot (which will resume from \
+         the current write position) or restore from backup."
+    ))]
+    SlotWalLost { slot: String, status: String },
+    #[snafu(display("invalid slot_start_lsn {lsn:?}: must be in 'X/Y' hex format"))]
+    InvalidStartLsn { lsn: String },
+    #[snafu(display("failed to query pg_replication_slots: {source}"))]
+    QueryFailed { source: tokio_postgres::Error },
+}
+
+pub(super) async fn build(
+    config: PostgresqlCdcConfig,
+    cx: crate::config::SourceContext,
+) -> crate::Result<crate::sources::Source> {
+    // Eagerly parse the connection string so the user gets a clear error at
+    // config-load time rather than after the source has started.
+    let pg_config: tokio_postgres::Config = config
+        .connection_string
+        .inner()
+        .parse()
+        .map_err(|source| BuildError::InvalidConnectionString { source })?;
+
+    let acknowledgements = cx.do_acknowledgements(config.acknowledgements);
+    let log_namespace = cx.log_namespace(config.log_namespace);
+
+    // Validate the slot *synchronously* during build() so misconfiguration
+    // surfaces as a config error instead of as a source that starts then
+    // immediately dies. The slot is validated over TLS if TLS is configured.
+    validate_slot(&pg_config, &config.tls, &config.replication_slot).await?;
+
+    let replication_config = build_replication_config(&pg_config, &config)?;
+
+    Ok(Box::pin(stream_events(
+        replication_config,
+        cx.out,
+        cx.shutdown,
+        acknowledgements,
+        log_namespace,
+    )))
+}
+
+async fn validate_slot(
+    pg_config: &tokio_postgres::Config,
+    tls: &Option<PostgresqlCdcTlsConfig>,
+    slot: &str,
+) -> Result<(), BuildError> {
+    // Connect using the same TLS posture the replication connection will
+    // use. Sending the libpq password cleartext during validation would
+    // defeat the user's explicit `tls.ca_file` configuration. The
+    // `verify_hostname` setting must reach this connection too — otherwise
+    // a user who set `verify_hostname = false` (to connect to a host whose
+    // certificate does not list the address in its SAN) would succeed on
+    // the replication path but fail here, because hostname verification on
+    // `MakeTlsConnector` is per-connection state on `ConnectConfiguration`,
+    // not on the builder.
+    let (client, connection_handle) = match tls {
+        Some(tls) => {
+            let mut builder = SslConnector::builder(SslMethod::tls_client()).map_err(|e| {
+                BuildError::TlsBuild {
+                    message: format!("SslConnector::builder failed: {e}"),
+                }
+            })?;
+            builder
+                .set_ca_file(tls.ca_file.clone())
+                .map_err(|e| BuildError::TlsBuild {
+                    message: format!("set_ca_file({:?}) failed: {e}", tls.ca_file),
+                })?;
+            // Always require a valid peer certificate chain; this matches
+            // both `SslMode::VerifyCa` and `SslMode::VerifyFull` on the
+            // replication connection.
+            builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+            let mut connector = MakeTlsConnector::new(builder.build());
+            if !tls.verify_hostname {
+                // verify-ca mode: validate the chain but skip the hostname
+                // check, matching `SslMode::VerifyCa` on the replication
+                // connection.
+                connector.set_callback(|cfg, _domain| {
+                    cfg.set_verify_hostname(false);
+                    Ok(())
+                });
+            }
+            let (client, connection) = pg_config
+                .connect(connector)
+                .await
+                .map_err(|source| BuildError::SetupConnect { source })?;
+            let handle = tokio::spawn(async move {
+                if let Err(e) = connection.await {
+                    tracing::warn!(
+                        message = "PostgreSQL setup connection ended with error",
+                        error = %e,
+                    );
+                }
+            });
+            (client, handle)
+        }
+        None => {
+            let (client, connection) = pg_config
+                .connect(NoTls)
+                .await
+                .map_err(|source| BuildError::SetupConnect { source })?;
+            let handle = tokio::spawn(async move {
+                if let Err(e) = connection.await {
+                    tracing::warn!(
+                        message = "PostgreSQL setup connection ended with error",
+                        error = %e,
+                    );
+                }
+            });
+            (client, handle)
+        }
+    };
+
+    // `pg_replication_slots.wal_status` was added in PostgreSQL 13. We
+    // support older servers (PG 10+, the minimum that supports logical
+    // replication) by issuing a column-free query when the server is too
+    // old. This matches `postgresql_metrics`, which performs similar
+    // runtime version detection rather than hard-requiring a specific
+    // major version. The `SlotWalLost` diagnostic is unavailable on PG 12
+    // and earlier; on those versions, monitor slot lag out-of-band (e.g.
+    // via the `postgresql_metrics` source).
+    let server_version: i32 = client
+        .query_one("SHOW server_version_num", &[])
+        .await
+        .map_err(|source| BuildError::QueryFailed { source })?
+        .get::<_, String>(0)
+        .parse()
+        .unwrap_or(0);
+    let has_wal_status = server_version >= 130_000;
+
+    let row = if has_wal_status {
+        client
+            .query_opt(
+                "SELECT plugin, confirmed_flush_lsn::text, active, \
+                     COALESCE(wal_status, 'unknown') AS wal_status \
+                 FROM pg_replication_slots WHERE slot_name = $1",
+                &[&slot],
+            )
+            .await
+    } else {
+        client
+            .query_opt(
+                "SELECT plugin, confirmed_flush_lsn::text, active \
+                 FROM pg_replication_slots WHERE slot_name = $1",
+                &[&slot],
+            )
+            .await
+    }
+    .map_err(|source| BuildError::QueryFailed { source })?;
+
+    let result = match row {
+        None => Err(BuildError::SlotMissing {
+            slot: slot.to_owned(),
+        }),
+        Some(row) => {
+            let plugin: String = row.get(0);
+            let active: bool = row.get(2);
+            let wal_status: String = if has_wal_status {
+                row.get(3)
+            } else {
+                "unknown".to_owned()
+            };
+            if plugin != "pgoutput" {
+                Err(BuildError::WrongOutputPlugin {
+                    slot: slot.to_owned(),
+                    plugin,
+                })
+            } else if active {
+                Err(BuildError::SlotAlreadyActive {
+                    slot: slot.to_owned(),
+                })
+            } else if wal_status == "lost" {
+                Err(BuildError::SlotWalLost {
+                    slot: slot.to_owned(),
+                    status: wal_status,
+                })
+            } else {
+                let confirmed: Option<String> = row.get(1);
+                tracing::info!(
+                    message = "Attaching to PostgreSQL replication slot.",
+                    slot = slot,
+                    server_version_num = server_version,
+                    confirmed_flush_lsn = confirmed.as_deref().unwrap_or("none"),
+                    wal_status = %wal_status,
+                );
+                Ok(())
+            }
+        }
+    };
+
+    // Close the client so the connection task can exit. Awaiting the
+    // background task ensures any final tracing it emits surfaces before
+    // we move on (and surfaces panics as JoinError on the next line).
+    drop(client);
+    if let Err(e) = connection_handle.await
+        && e.is_panic()
+    {
+        tracing::error!(
+            message = "Setup connection task panicked",
+            error = %e,
+        );
+    }
+    result
+}
+
+/// Builds the `pgwire-replication` config from the user's libpq URI plus the
+/// CDC-specific knobs.
+///
+/// ## Safety contract
+///
+/// The returned `PgwireConfig` carries the password in a `String`. The type
+/// derives `Debug` upstream and the password is not redacted. **Callers must
+/// not** format the returned value with `{:?}`, `?cfg`, or any tracing macro
+/// that would render it. Only individual safe fields may be logged.
+fn build_replication_config(
+    pg_config: &tokio_postgres::Config,
+    cdc_config: &PostgresqlCdcConfig,
+) -> Result<PgwireConfig, BuildError> {
+    let user = pg_config
+        .get_user()
+        .ok_or(BuildError::MissingConnectionField { field: "user" })?;
+    let password_bytes = pg_config
+        .get_password()
+        .ok_or(BuildError::MissingConnectionField { field: "password" })?;
+    // Use strict UTF-8 decoding. `from_utf8_lossy` would silently substitute
+    // U+FFFD for non-UTF-8 bytes, producing a credential that does not match
+    // the user's actual password and burying the root cause in a confusing
+    // auth-failed error.
+    let password = std::str::from_utf8(password_bytes)
+        .map_err(|_| BuildError::NonUtf8Password)?
+        .to_owned();
+    let database = pg_config
+        .get_dbname()
+        .ok_or(BuildError::MissingConnectionField { field: "dbname" })?;
+    let host = first_host(pg_config).ok_or(BuildError::MissingConnectionField { field: "host" })?;
+    let port = pg_config.get_ports().first().copied().unwrap_or(5432);
+
+    let start_lsn = match cdc_config.slot_start_lsn.as_deref() {
+        Some(s) => Lsn::parse(s).map_err(|_| BuildError::InvalidStartLsn { lsn: s.to_owned() })?,
+        None => Lsn::ZERO,
+    };
+
+    let tls = match &cdc_config.tls {
+        None => PgwireTlsConfig::disabled(),
+        Some(tls) => {
+            let mode = if tls.verify_hostname {
+                SslMode::VerifyFull
+            } else {
+                SslMode::VerifyCa
+            };
+            PgwireTlsConfig {
+                mode,
+                ca_pem_path: Some(tls.ca_file.clone()),
+                ..Default::default()
+            }
+        }
+    };
+
+    Ok(PgwireConfig {
+        host: host.to_owned(),
+        port,
+        user: user.to_owned(),
+        password,
+        database: database.to_owned(),
+        tls,
+        slot: cdc_config.replication_slot.clone(),
+        publication: cdc_config.publication_name.clone(),
+        start_lsn,
+        status_interval: STATUS_UPDATE_INTERVAL,
+        ..PgwireConfig::default()
+    })
+}
+
+fn first_host(pg_config: &tokio_postgres::Config) -> Option<String> {
+    pg_config.get_hosts().first().and_then(|h| match h {
+        tokio_postgres::config::Host::Tcp(s) => Some(s.clone()),
+        #[cfg(unix)]
+        tokio_postgres::config::Host::Unix(p) => p.to_str().map(str::to_owned),
+        #[cfg(not(unix))]
+        _ => None,
+    })
+}
+
+async fn stream_events(
+    replication_config: PgwireConfig,
+    mut out: SourceSender,
+    mut shutdown: ShutdownSignal,
+    acknowledgements: bool,
+    log_namespace: LogNamespace,
+) -> Result<(), ()> {
+    let mut client = match ReplicationClient::connect(replication_config).await {
+        Ok(c) => c,
+        Err(error) => {
+            emit!(PostgresqlCdcReplicationError {
+                error: error.to_string(),
+            });
+            return Err(());
+        }
+    };
+
+    let mut parser = PgoutputParser::new();
+    let mut tracker = LsnTracker::new();
+    let mut tx_meta: Option<TxMeta> = None;
+    let mut tx_receivers: Vec<BatchStatusReceiver> = Vec::new();
+    let mut last_advanced = 0u64;
+    // Edge-triggered tracker for the back-pressure warning. We only want to
+    // log once when the tracker fills and once when it drains, not on every
+    // loop iteration while a slow sink keeps us saturated.
+    let mut tracker_was_full = false;
+    let bytes_received = register!(BytesReceived::from(Protocol::TCP));
+    let events_received = register!(EventsReceived);
+
+    loop {
+        // Poll the tracker first so confirmed LSNs are forwarded promptly.
+        if let Some(new_lsn) = tracker.poll_confirmed()
+            && new_lsn != last_advanced
+        {
+            client.update_applied_lsn(Lsn::from_u64(new_lsn));
+            last_advanced = new_lsn;
+        }
+        if let Some((lsn, status)) = tracker.failure() {
+            emit!(PostgresqlCdcSinkAckFailed {
+                lsn,
+                status: batch_status_name(status),
+            });
+            client.stop();
+            return Err(());
+        }
+
+        // Back-pressure: when the LSN tracker is at its cap, stop pulling
+        // new events off the wire. The select! arm guard below conditionally
+        // skips `client.recv()`, so the only futures driving the select are
+        // shutdown and the periodic tracker poll, letting downstream acks
+        // drain the tracker before we accept more work. This keeps a slow
+        // sink from OOMing the source by accumulating unbounded LSN state.
+        let tracker_is_full = tracker.is_full();
+        if tracker_is_full && !tracker_was_full {
+            tracing::warn!(
+                message = "LSN tracker at capacity; pausing replication intake until acks drain.",
+            );
+        } else if !tracker_is_full && tracker_was_full {
+            tracing::info!(
+                message = "LSN tracker drained below capacity; resuming replication intake.",
+            );
+        }
+        tracker_was_full = tracker_is_full;
+
+        tokio::select! {
+            biased;
+
+            _ = &mut shutdown => {
+                tracing::info!(message = "Shutdown requested; stopping replication stream.");
+                client.stop();
+                return Ok(());
+            }
+
+            event = client.recv(), if !tracker.is_full() => match event {
+                Ok(Some(event)) => {
+                    if let Err(()) = handle_event(
+                        event,
+                        &mut parser,
+                        &mut tracker,
+                        &mut tx_meta,
+                        &mut tx_receivers,
+                        &mut out,
+                        acknowledgements,
+                        log_namespace,
+                        &bytes_received,
+                        &events_received,
+                    ).await {
+                        return Err(());
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!(message = "Replication stream ended.");
+                    return Ok(());
+                }
+                Err(error) => {
+                    emit!(PostgresqlCdcReplicationError {
+                        error: error.to_string(),
+                    });
+                    return Err(());
+                }
+            },
+
+            _ = sleep(TRACKER_POLL_INTERVAL) => {
+                // Wake up to poll the tracker. The next loop iteration handles
+                // forwarding any confirmed LSN to the replication client.
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_event(
+    event: ReplicationEvent,
+    parser: &mut PgoutputParser,
+    tracker: &mut LsnTracker,
+    tx_meta: &mut Option<TxMeta>,
+    tx_receivers: &mut Vec<BatchStatusReceiver>,
+    out: &mut SourceSender,
+    acknowledgements: bool,
+    log_namespace: LogNamespace,
+    bytes_received: &Registered<BytesReceived>,
+    events_received: &Registered<EventsReceived>,
+) -> Result<(), ()> {
+    match event {
+        ReplicationEvent::Begin {
+            final_lsn,
+            xid,
+            commit_time_micros,
+        } => {
+            *tx_meta = Some(TxMeta {
+                final_lsn: final_lsn.as_u64(),
+                transaction_id: xid,
+                commit_timestamp: pg_micros_to_utc(commit_time_micros),
+            });
+            Ok(())
+        }
+        ReplicationEvent::Commit { .. } => {
+            if let Some(tx) = tx_meta.take() {
+                for rx in tx_receivers.drain(..) {
+                    tracker.track(tx.final_lsn, rx);
+                }
+                if !acknowledgements {
+                    tracker.mark_delivered_immediately(tx.final_lsn);
+                }
+            }
+            Ok(())
+        }
+        ReplicationEvent::XLogData { data, .. } => {
+            bytes_received.emit(vector_lib::internal_event::ByteSize(data.len()));
+            let tx_snapshot = *tx_meta;
+            match parser.parse(&data, tx_snapshot.as_ref(), log_namespace) {
+                Ok(Parsed::NoEvent) => Ok(()),
+                Ok(Parsed::Rows(rows)) => {
+                    if tx_snapshot.is_none() {
+                        emit!(PostgresqlCdcProtocolViolation {
+                            detail: "row message outside any transaction",
+                        });
+                        return Err(());
+                    }
+                    let logs: Vec<LogEvent> = rows.into_iter().map(|r| r.log).collect();
+                    if let Some(rx) =
+                        send_log_events(logs, out, acknowledgements, events_received).await?
+                    {
+                        tx_receivers.push(rx);
+                    }
+                    Ok(())
+                }
+                Err(error) => {
+                    emit!(PostgresqlCdcParseError {
+                        error: error.to_string(),
+                    });
+                    Err(())
+                }
+            }
+        }
+        ReplicationEvent::KeepAlive { .. } => Ok(()),
+        ReplicationEvent::Message {
+            transactional,
+            lsn,
+            prefix,
+            content,
+        } => {
+            bytes_received.emit(vector_lib::internal_event::ByteSize(content.len()));
+            let (track_lsn, log) = if transactional {
+                let Some(tx) = tx_meta.as_ref() else {
+                    emit!(PostgresqlCdcProtocolViolation {
+                        detail: "transactional logical message outside any transaction",
+                    });
+                    return Err(());
+                };
+                (
+                    tx.final_lsn,
+                    build_message_event(
+                        true,
+                        lsn.as_u64(),
+                        &prefix,
+                        &content,
+                        Some(tx),
+                        log_namespace,
+                    ),
+                )
+            } else {
+                (
+                    lsn.as_u64(),
+                    build_message_event(
+                        false,
+                        lsn.as_u64(),
+                        &prefix,
+                        &content,
+                        None,
+                        log_namespace,
+                    ),
+                )
+            };
+            let rx = send_log_events(vec![log], out, acknowledgements, events_received).await?;
+            if transactional {
+                if let Some(rx) = rx {
+                    tx_receivers.push(rx);
+                }
+            } else if let Some(rx) = rx {
+                tracker.track(track_lsn, rx);
+            } else {
+                tracker.mark_delivered_immediately(track_lsn);
+            }
+            Ok(())
+        }
+        ReplicationEvent::StoppedAt { reached } => {
+            tracing::info!(message = "Replication reached stop LSN", lsn = %reached);
+            Ok(())
+        }
+    }
+}
+
+const fn batch_status_name(status: vector_lib::event::BatchStatus) -> &'static str {
+    match status {
+        vector_lib::event::BatchStatus::Delivered => "delivered",
+        vector_lib::event::BatchStatus::Errored => "errored",
+        vector_lib::event::BatchStatus::Rejected => "rejected",
+    }
+}
+
+async fn send_log_events(
+    logs: Vec<LogEvent>,
+    out: &mut SourceSender,
+    acknowledgements: bool,
+    events_received: &Registered<EventsReceived>,
+) -> Result<Option<BatchStatusReceiver>, ()> {
+    let count = logs.len();
+    let byte_size = logs.estimated_json_encoded_size_of();
+    events_received.emit(CountByteSize(count, byte_size));
+
+    let (events, receiver) = if acknowledgements {
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+        let events: Vec<Event> = logs
+            .into_iter()
+            .map(|log| {
+                let event: Event = log.into();
+                event.with_batch_notifier(&batch)
+            })
+            .collect();
+        drop(batch);
+        (events, Some(receiver))
+    } else {
+        (logs.into_iter().map(Into::into).collect(), None)
+    };
+
+    match out.send_batch(events).await {
+        Ok(()) => Ok(receiver),
+        Err(_error) => {
+            emit!(StreamClosedError { count });
+            Err(())
+        }
+    }
+}
+
+fn build_message_event(
+    transactional: bool,
+    lsn: u64,
+    prefix: &str,
+    content: &bytes::Bytes,
+    tx_meta: Option<&TxMeta>,
+    log_namespace: LogNamespace,
+) -> LogEvent {
+    use crate::sources::postgresql_cdc::config::PostgresqlCdcConfig;
+    use vector_lib::config::LegacyKey;
+    use vrl::path;
+
+    let mut log = LogEvent::default();
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("operation"))),
+        path!("operation"),
+        "message",
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("transactional"))),
+        path!("transactional"),
+        Value::Boolean(transactional),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("lsn"))),
+        path!("lsn"),
+        format_lsn(lsn),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("prefix"))),
+        path!("prefix"),
+        prefix.to_owned(),
+    );
+    log_namespace.insert_source_metadata(
+        PostgresqlCdcConfig::NAME,
+        &mut log,
+        Some(LegacyKey::Overwrite(path!("content"))),
+        path!("content"),
+        Value::Bytes(content.clone()),
+    );
+    if let Some(tx) = tx_meta {
+        log_namespace.insert_source_metadata(
+            PostgresqlCdcConfig::NAME,
+            &mut log,
+            Some(LegacyKey::Overwrite(path!("transaction_id"))),
+            path!("transaction_id"),
+            Value::Integer(i64::from(tx.transaction_id)),
+        );
+        log_namespace.insert_source_metadata(
+            PostgresqlCdcConfig::NAME,
+            &mut log,
+            Some(LegacyKey::Overwrite(path!("transaction_timestamp"))),
+            path!("transaction_timestamp"),
+            Value::from(tx.commit_timestamp),
+        );
+    }
+    log_namespace.insert_standard_vector_source_metadata(
+        &mut log,
+        PostgresqlCdcConfig::NAME,
+        Utc::now(),
+    );
+    // `new`/`old`/`schema`/`table`/`transaction_id`/`transaction_timestamp`
+    // are deliberately absent on `message` events (the latter two are only
+    // present for transactional messages, above). Consumers should
+    // pattern-match by `operation == "message"` and key-absence rather
+    // than checking for `null`, so we do not insert sentinel nulls.
+    log
+}
+
+fn pg_micros_to_utc(micros: i64) -> chrono::DateTime<Utc> {
+    let unix_micros = micros.saturating_add(PG_EPOCH_OFFSET_MICROS);
+    Utc.timestamp_micros(unix_micros)
+        .single()
+        .unwrap_or_else(|| {
+            // Out-of-range or ambiguous PG timestamp. This should not occur in
+            // practice — `pg_micros_to_utc(0)` covers the maximum offset and
+            // `i64` micros covers the chrono range — but if the server emits a
+            // value chrono cannot resolve, log it so the synthetic Unix-epoch
+            // fallback below is visible to operators rather than silently
+            // tagging events with `1970-01-01`.
+            tracing::warn!(
+                message = "PostgreSQL commit timestamp out of representable range; \
+                       falling back to Unix epoch.",
+                pg_micros = micros,
+            );
+            Utc.timestamp_opt(0, 0)
+                .single()
+                .expect("Unix epoch is always representable as DateTime<Utc>")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vector_lib::sensitive_string::SensitiveString;
+
+    fn base_config() -> PostgresqlCdcConfig {
+        PostgresqlCdcConfig {
+            connection_string: SensitiveString::from("postgres://u:p@127.0.0.1:5432/db".to_owned()),
+            replication_slot: "slot".to_owned(),
+            publication_name: "pub".to_owned(),
+            slot_start_lsn: None,
+            tls: None,
+            acknowledgements: Default::default(),
+            log_namespace: None,
+        }
+    }
+
+    fn parse_pg(uri: &str) -> tokio_postgres::Config {
+        uri.parse().expect("valid libpq URI")
+    }
+
+    #[test]
+    fn pg_epoch_translates_to_unix() {
+        // PostgreSQL epoch == 2000-01-01 00:00:00 UTC, which is 946684800
+        // seconds (946684800_000_000 microseconds) past Unix epoch.
+        let pg_zero = pg_micros_to_utc(0);
+        assert_eq!(pg_zero.timestamp(), 946_684_800);
+    }
+
+    #[test]
+    fn invalid_start_lsn_surfaces_typed_error() {
+        let mut cfg = base_config();
+        cfg.slot_start_lsn = Some("not-an-lsn".to_owned());
+        let pg = parse_pg("postgres://u:p@127.0.0.1:5432/db");
+        let err = build_replication_config(&pg, &cfg).expect_err("must reject malformed LSN");
+        assert!(
+            matches!(err, BuildError::InvalidStartLsn { ref lsn } if lsn == "not-an-lsn"),
+            "expected InvalidStartLsn, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_password_surfaces_typed_error() {
+        let cfg = base_config();
+        // libpq URI with user but no password.
+        let pg = parse_pg("postgres://u@127.0.0.1:5432/db");
+        let err = build_replication_config(&pg, &cfg).expect_err("must reject missing password");
+        assert!(
+            matches!(
+                err,
+                BuildError::MissingConnectionField { field: "password" }
+            ),
+            "expected MissingConnectionField{{password}}, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_dbname_surfaces_typed_error() {
+        let cfg = base_config();
+        // libpq URI with user/password but no dbname.
+        let pg = parse_pg("postgres://u:p@127.0.0.1:5432");
+        let err = build_replication_config(&pg, &cfg).expect_err("must reject missing dbname");
+        assert!(
+            matches!(err, BuildError::MissingConnectionField { field: "dbname" }),
+            "expected MissingConnectionField{{dbname}}, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn non_utf8_password_surfaces_typed_error() {
+        let cfg = base_config();
+        // Construct a tokio_postgres::Config with a non-UTF-8 password byte
+        // sequence. The libpq URI parser percent-decodes, so we set the
+        // password directly on the builder to keep this purely about the
+        // UTF-8 check inside `build_replication_config`.
+        let mut pg = parse_pg("postgres://u@127.0.0.1:5432/db");
+        pg.password([0xff, 0xfe, 0xfd]);
+        let err = build_replication_config(&pg, &cfg).expect_err("must reject non-UTF-8 password");
+        assert!(
+            matches!(err, BuildError::NonUtf8Password),
+            "expected NonUtf8Password, got {err:?}"
+        );
+    }
+}

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -359,6 +359,11 @@ impl PostgresqlClient {
 struct DatnameFilter {
     pg_stat_database_sql: String,
     pg_stat_database_conflicts_sql: String,
+    /// Optional WHERE-clause filter (without the `WHERE` keyword) keyed on
+    /// `pg_replication_slots.database`, so slot metrics respect the same
+    /// include/exclude rules as per-database stats. None when no filter
+    /// was configured.
+    pg_replication_slots_filter_sql: Option<String>,
     match_params: Vec<String>,
 }
 
@@ -404,9 +409,23 @@ impl DatnameFilter {
             pg_stat_database_conflicts_sql += &match_sql;
         }
 
+        // Build a copy of the match SQL keyed on `database` instead of
+        // `datname` for the slot query. `pg_replication_slots` always has a
+        // value for `database` on logical slots, and NULL for physical
+        // slots — physical slots are kept out of `include_null`/`exclude_null`
+        // handling because they don't carry a database identity in the same
+        // sense (they're cluster-wide). The same parameter indices are
+        // reused so we can share `match_params`.
+        let pg_replication_slots_filter_sql = if match_sql.is_empty() {
+            None
+        } else {
+            Some(match_sql.replace("datname ", "database "))
+        };
+
         Self {
             pg_stat_database_sql,
             pg_stat_database_conflicts_sql,
+            pg_replication_slots_filter_sql,
             match_params,
         }
     }
@@ -483,6 +502,52 @@ impl DatnameFilter {
         client
             .query_one("SELECT * FROM pg_stat_bgwriter", &[])
             .await
+    }
+
+    async fn pg_replication_slots(
+        &self,
+        client: &Client,
+        version: usize,
+    ) -> Result<Vec<Row>, PgError> {
+        let lsn_func = if version >= 100000 {
+            "pg_current_wal_lsn()"
+        } else {
+            "pg_current_xlog_location()"
+        };
+        let diff_func = if version >= 100000 {
+            "pg_wal_lsn_diff"
+        } else {
+            "pg_xlog_location_diff"
+        };
+        let wal_status = if version >= 130000 {
+            "wal_status"
+        } else {
+            "'unknown' AS wal_status"
+        };
+
+        let mut sql = format!(
+            "SELECT slot_name, active, database, {}, \
+                    CASE WHEN NOT pg_is_in_recovery() \
+                         THEN {}({}, restart_lsn)::float8 \
+                         ELSE NULL END AS restart_lag_bytes, \
+                    CASE WHEN confirmed_flush_lsn IS NOT NULL AND NOT pg_is_in_recovery() \
+                         THEN {}({}, confirmed_flush_lsn)::float8 \
+                         ELSE NULL END AS confirmed_lag_bytes \
+             FROM pg_replication_slots",
+            wal_status, diff_func, lsn_func, diff_func, lsn_func
+        );
+
+        // Apply the same include/exclude database filter the user
+        // configured for pg_stat_database. Physical slots have a NULL
+        // `database` and are always emitted — they describe cluster-wide
+        // state, not a single database.
+        if let Some(filter) = &self.pg_replication_slots_filter_sql {
+            sql.push_str(" WHERE (database IS NULL OR ");
+            sql.push_str(filter);
+            sql.push(')');
+        }
+
+        client.query(&sql, self.get_match_params().as_slice()).await
     }
 }
 
@@ -568,6 +633,8 @@ impl PostgresqlMetrics {
                 .boxed(),
             self.collect_pg_stat_database_conflicts(&client).boxed(),
             self.collect_pg_stat_bgwriter(&client).boxed(),
+            self.collect_pg_replication_slots(&client, client_version)
+                .boxed(),
         ])
         .await
         {
@@ -861,6 +928,62 @@ impl PostgresqlMetrics {
         ))
     }
 
+    async fn collect_pg_replication_slots(
+        &self,
+        client: &Client,
+        client_version: usize,
+    ) -> Result<(Vec<Metric>, usize), CollectError> {
+        let rows = self
+            .datname_filter
+            .pg_replication_slots(client, client_version)
+            .await
+            .context(QuerySnafu)?;
+
+        let mut metrics = Vec::with_capacity(5 * rows.len());
+        let mut reader = RowReader::default();
+        for row in rows.iter() {
+            let slot_name = reader.read::<&str>(row, "slot_name")?;
+            let db = reader.read::<Option<&str>>(row, "database")?.unwrap_or("");
+            let active = reader.read::<bool>(row, "active")?;
+            let wal_status = reader.read::<&str>(row, "wal_status")?;
+
+            let tags = tags!(
+                self.tags,
+                "slot_name" => slot_name,
+                "db" => db,
+                "wal_status" => wal_status
+            );
+
+            metrics.push(self.create_metric(
+                "pg_replication_slots_active",
+                gauge!(if active { 1.0 } else { 0.0 }),
+                tags.clone(),
+            ));
+
+            // Lag metrics are NULL when the slot has no committed position
+            // (e.g. on a standby where `pg_current_wal_lsn()` is unavailable,
+            // or when `confirmed_flush_lsn` has never been set). Emit only
+            // when a real value is present, so a missing data point is
+            // distinguishable from a genuine 0-byte lag in dashboards and
+            // alerts.
+            if let Some(restart_lag) = reader.read::<Option<f64>>(row, "restart_lag_bytes")? {
+                metrics.push(self.create_metric(
+                    "pg_replication_slots_restart_lag_bytes",
+                    gauge!(restart_lag),
+                    tags.clone(),
+                ));
+            }
+            if let Some(confirmed_lag) = reader.read::<Option<f64>>(row, "confirmed_lag_bytes")? {
+                metrics.push(self.create_metric(
+                    "pg_replication_slots_confirmed_lag_bytes",
+                    gauge!(confirmed_lag),
+                    tags,
+                ));
+            }
+        }
+        Ok((metrics, reader.into_inner()))
+    }
+
     fn create_metric(&self, name: &str, value: MetricValue, tags: MetricTags) -> Metric {
         Metric::new(name, MetricKind::Absolute, value)
             .with_namespace(self.namespace.clone())
@@ -1011,6 +1134,7 @@ mod integration_tests {
         test_util::{
             components::{PULL_SOURCE_TAGS, assert_source_compliance},
             integration::postgres::{pg_socket, pg_url},
+            random_string,
         },
         tls,
     };
@@ -1185,6 +1309,58 @@ mod integration_tests {
 
             if let Some(db) = metric.tags().unwrap().get("db") {
                 assert!(db == "template1");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_replication_slots() {
+        let url = pg_url();
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(connection);
+
+        // Use a randomized slot name so parallel test runs and leftover
+        // state from earlier aborted runs do not collide. Drop-if-exists
+        // before creating so a previously-leaked slot of the same name
+        // does not fail the create.
+        let slot_name = format!("vector_test_metrics_{}", random_string(8).to_lowercase());
+        let _ = client
+            .query(
+                "SELECT pg_drop_replication_slot($1) WHERE EXISTS \
+                 (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+                &[&slot_name],
+            )
+            .await;
+
+        // Create a temporary slot. `pg_create_logical_replication_slot`
+        // requires `wal_level=logical`. If the test environment does not
+        // support it, skip this check.
+        match client
+            .query(
+                "SELECT pg_create_logical_replication_slot($1, 'pgoutput')",
+                &[&slot_name],
+            )
+            .await
+        {
+            Ok(_) => {
+                let events = test_postgresql_metrics(url, None, None, None).await;
+
+                assert!(
+                    events
+                        .iter()
+                        .any(|e| e.as_metric().name() == "pg_replication_slots_active")
+                );
+
+                // Clean up
+                let _ = client
+                    .query("SELECT pg_drop_replication_slot($1)", &[&slot_name])
+                    .await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    message = "Skipping replication slot test; environment does not support logical replication.",
+                    error = %e
+                );
             }
         }
     }

--- a/src/test_util/integration.rs
+++ b/src/test_util/integration.rs
@@ -1,6 +1,7 @@
 #[cfg(any(
     feature = "postgres_sink-integration-tests",
-    feature = "postgresql_metrics-integration-tests"
+    feature = "postgresql_metrics-integration-tests",
+    feature = "postgresql_cdc-integration-tests"
 ))]
 pub mod postgres {
     use std::path::PathBuf;

--- a/tests/integration/postgresql_cdc/config/compose.yaml
+++ b/tests/integration/postgresql_cdc/config/compose.yaml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+  postgres:
+    image: docker.io/postgres:${CONFIG_VERSION}
+    environment:
+      - POSTGRES_USER=vector
+      - POSTGRES_PASSWORD=vector
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=100
+      - -c
+      - max_wal_senders=100
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vector"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+networks:
+  default:
+    name: ${VECTOR_NETWORK}
+    external: true

--- a/tests/integration/postgresql_cdc/config/test.yaml
+++ b/tests/integration/postgresql_cdc/config/test.yaml
@@ -1,0 +1,16 @@
+features:
+  - postgresql_cdc-integration-tests
+
+test_filter: "::postgresql_cdc::"
+
+env:
+  PG_HOST: postgres
+
+matrix:
+  version: ["16"]
+
+# changes to these files/paths will invoke the integration test in CI
+# expressions are evaluated using https://github.com/micromatch/picomatch
+paths:
+  - "src/sources/postgresql_cdc/**"
+  - "tests/integration/postgresql_cdc/**"

--- a/website/cue/reference/components/sources/generated/postgresql_cdc.cue
+++ b/website/cue/reference/components/sources/generated/postgresql_cdc.cue
@@ -1,0 +1,87 @@
+package metadata
+
+generated: components: sources: postgresql_cdc: configuration: {
+	acknowledgements: {
+		deprecated: true
+		description: """
+			End-to-end acknowledgement configuration.
+
+			When acknowledgements are enabled (the default for this source) the
+			confirmed-flush LSN is only advanced after every downstream sink has
+			acknowledged the events produced by the corresponding transaction.
+			"""
+		required: false
+		type: object: options: enabled: {
+			description: "Whether or not end-to-end acknowledgements are enabled for this source."
+			required:    false
+			type: bool: {}
+		}
+	}
+	connection_string: {
+		description: """
+			libpq-style connection URI for the PostgreSQL server.
+
+			Must NOT include replication-specific parameters such as `replication`
+			or `database=replication`; the source sets those internally on the
+			replication connection.
+			"""
+		required: true
+		type: string: examples: ["postgres://vector:password@db.example.com:5432/app"]
+	}
+	publication_name: {
+		description: """
+			Name of an existing publication to subscribe to. The publication
+			determines which tables and DML operations are replicated.
+			"""
+		required: true
+		type: string: examples: ["vector_pub"]
+	}
+	replication_slot: {
+		description: """
+			Name of an existing logical replication slot that uses the `pgoutput`
+			output plugin. The slot must be created out-of-band (e.g. via
+			`SELECT pg_create_logical_replication_slot('my_slot', 'pgoutput')`) —
+			the source will not create or drop it.
+			"""
+		required: true
+		type: string: examples: ["vector_slot"]
+	}
+	slot_start_lsn: {
+		description: """
+			Optional LSN to start streaming from, in `X/Y` hex format.
+
+			If unset, the source passes `0/0` to `START_REPLICATION`, which
+			causes PostgreSQL to resume from the slot's `confirmed_flush_lsn`
+			automatically. Override only for advanced replay scenarios.
+			"""
+		required: false
+		type: string: examples: ["16/B374D848"]
+	}
+	tls: {
+		description: """
+			TLS configuration for the connection. If unset, the source connects
+			without TLS.
+			"""
+		required: false
+		type: object: options: {
+			ca_file: {
+				description: """
+					Absolute path to a PEM-encoded CA certificate file used to verify the
+					Postgres server certificate.
+					"""
+				required: true
+				type: string: examples: ["/etc/ssl/certs/ca.pem"]
+			}
+			verify_hostname: {
+				description: """
+					Whether to verify the server hostname against the certificate.
+
+					Set to `false` to verify the certificate chain only (equivalent to
+					`sslmode=verify-ca`). Default is `true` (`sslmode=verify-full`).
+					"""
+				required: false
+				type: bool: default: true
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/postgresql_cdc.cue
+++ b/website/cue/reference/components/sources/postgresql_cdc.cue
@@ -1,0 +1,551 @@
+package metadata
+
+components: sources: postgresql_cdc: {
+	title: "PostgreSQL CDC"
+
+	description: """
+		Streams change-data-capture events from a [PostgreSQL](\(urls.postgresql)) database using the
+		built-in logical replication protocol (`pgoutput`). Captures INSERTs, UPDATEs, DELETEs, and
+		TRUNCATEs along with the transaction context they belong to, and integrates with Vector's
+		end-to-end acknowledgement system so the slot's `confirmed_flush_lsn` only advances after the
+		downstream sink has confirmed durable delivery.
+		"""
+
+	classes: {
+		commonly_used: false
+		delivery:      "at_least_once"
+		deployment_roles: ["aggregator", "sidecar"]
+		development:   "beta"
+		egress_method: "stream"
+		stateful:      true
+	}
+
+	features: {
+		auto_generated:   true
+		acknowledgements: true
+		collect: {
+			checkpoint: enabled: true
+			tls: {
+				enabled:                true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+				enabled_by_scheme:      false
+			}
+			from: {
+				service: services.postgres
+				interface: {
+					socket: {
+						direction: "outgoing"
+						protocols: ["tcp"]
+						ssl: "optional"
+					}
+				}
+			}
+		}
+		multiline: enabled: false
+	}
+
+	support: {
+		requirements: [
+			"""
+				PostgreSQL 10 or newer is required — the minimum version that supports logical
+				replication via the `pgoutput` plugin. The source uses `pg_replication_slots.wal_status`
+				for slot-health diagnostics when available; that column was added in PostgreSQL 13,
+				and on older servers the diagnostic is degraded to `"unknown"` while the rest of the
+				source continues to function. The `SlotWalLost` startup error is therefore
+				unavailable on PostgreSQL 12 and earlier; monitor slot lag out-of-band on those
+				versions (for example via the `postgresql_metrics` source).
+				""",
+			"""
+				The PostgreSQL server must have `wal_level = logical` set, plus `max_replication_slots`
+				and `max_wal_senders` configured high enough to accommodate this source. Restart the
+				server after changing `wal_level`.
+				""",
+			"""
+				A logical replication slot using the `pgoutput` output plugin must already exist before
+				the source starts. Create it once via `SELECT pg_create_logical_replication_slot('<slot>',
+				'pgoutput');`. This source intentionally does not create or drop slots — that is an
+				operator responsibility, because an abandoned slot can cause unbounded WAL growth and
+				eventually take the database down. On startup the source validates the slot:
+				it must exist, use the `pgoutput` plugin, not be attached to another consumer, and
+				not be in a `lost` WAL state. Each of those conditions surfaces as a clear
+				configuration-load error rather than a silent failure later.
+				""",
+			"""
+				A publication that includes every table you want to replicate must exist:
+				`CREATE PUBLICATION <pub> FOR TABLE table1, table2, ...;`.
+				""",
+			"""
+				The configured user must have the `REPLICATION` role attribute (or be a superuser).
+				Use the minimum-privilege role described below — `SUPERUSER` is **not** required and
+				should be avoided in production.
+
+				```sql
+				-- 1. Create a role with replication privileges and a password.
+				CREATE ROLE vector_cdc WITH LOGIN REPLICATION PASSWORD 'change_me';
+
+				-- 2. Allow the role to connect to the database.
+				GRANT CONNECT ON DATABASE app TO vector_cdc;
+
+				-- 3. Grant SELECT on the tables the publication covers. SELECT is what
+				--    pgoutput uses to read the row payloads from the table heap when
+				--    a transaction commits; without it, the slot will fail to decode.
+				GRANT USAGE ON SCHEMA public TO vector_cdc;
+				GRANT SELECT ON TABLE public.orders, public.customers TO vector_cdc;
+
+				-- 4. If you use row-level security, the publication must be created
+				--    with `(publish_via_partition_root = true)` and the role needs
+				--    `BYPASSRLS`, or you must add explicit RLS policies that allow
+				--    `vector_cdc` to read the rows you intend to replicate.
+				```
+
+				The role does **not** need `CREATEDB`, `CREATEROLE`, or any table-level
+				INSERT/UPDATE/DELETE privileges.
+				""",
+		]
+
+		warnings: [
+			"""
+				`UPDATE` and `DELETE` events only include the row's primary-key columns by default. To
+				receive the full pre-image of the row in the `old` field, set the table's replica identity
+				to `FULL`: `ALTER TABLE <table> REPLICA IDENTITY FULL;`. This has a moderate write-amplification cost.
+				""",
+			"""
+				PostgreSQL's logical replication is at-least-once. After a Vector restart the last
+				transaction that was acknowledged before the disconnect may be re-delivered. Downstream
+				sinks or transforms that need exactly-once semantics should dedupe on the `lsn` field.
+				""",
+		]
+		notices: []
+	}
+
+	installation: {
+		platform_name: null
+	}
+
+	configuration: generated.components.sources.postgresql_cdc.configuration
+
+	how_it_works: {
+		lsn_acknowledgement: {
+			title: "End-to-end LSN acknowledgement"
+			body: """
+				PostgreSQL's logical replication is driven by *Log Sequence Numbers* (LSNs). The slot has
+				two LSN positions:
+
+				- `restart_lsn` — the earliest WAL segment Postgres must retain for this slot.
+				- `confirmed_flush_lsn` — the position the consumer has confirmed as durable.
+
+				Vector advances `confirmed_flush_lsn` only after every event from a given transaction has
+				been acknowledged by the downstream sink. This is enforced by attaching a per-batch
+				notifier to every event emitted from a transaction and waiting for *all* of them to
+				resolve before reporting that transaction's commit LSN as the new applied position.
+
+				A long-running transaction with 10,000 row changes therefore produces 10,000 events all
+				tagged with the same `lsn`, and the slot only advances once for the whole transaction.
+				A `BatchNotifier` whose sender drops without ever firing (which can happen if a
+				downstream component is reconfigured mid-stream) is treated the same as `Delivered`
+				for LSN-advancement purposes, matching the behaviour of the `kafka` source.
+
+				If the sink reports `Errored` or `Rejected` for any batch, the source halts LSN
+				advancement, surfaces the error in the logs, and stops accepting new events from the
+				replication stream. The slot remains pinned at the last successfully acknowledged LSN,
+				preventing data loss.
+				"""
+		}
+
+		transaction_boundaries: {
+			title: "Transaction boundaries"
+			body: """
+				`pgoutput` emits transactions atomically and in commit order. You will always see the
+				complete sequence `Begin → row events → Commit` for one transaction before any messages
+				from the next. The source uses this guarantee to attach the transaction's metadata
+				(`transaction_id`, `transaction_timestamp`, `lsn`) to every row event without needing to
+				match begin/commit explicitly.
+				"""
+		}
+
+		data_types: {
+			title: "Column type mapping"
+			body: """
+				`pgoutput` emits column values in PostgreSQL's text representation by default. The source
+				maps them to Vector's native `Value` variants as follows:
+
+				| PostgreSQL type                     | Vector field type     | Notes                                                                                  |
+				|-------------------------------------|-----------------------|----------------------------------------------------------------------------------------|
+				| `bool`                              | boolean               | `t` / `f` from the wire                                                                |
+				| `int2`, `int4`, `int8`              | integer               | Parsed as `i64`. Values outside the i64 range fall back to the raw text string.        |
+				| `float4`, `float8`                  | float                 | Parsed as `f64`. `NaN`/`Inf` fall back to the raw text string.                         |
+				| `numeric`                           | string                | **Preserved exactly as text.** Casting to float would silently lose precision.         |
+				| `text`, `varchar`, `char`, `name`   | string                | Raw UTF-8 bytes; stored internally as `Value::Bytes` and serialized as a JSON string by downstream sinks. |
+				| `bytea`                             | bytes                 | Decoded from the wire's `\\x…` hex form into raw bytes.                                |
+				| `json`, `jsonb`                     | object                | Parsed with `serde_json`. Malformed JSON falls back to the raw text string.            |
+				| `date`, `timestamp`, `timestamptz`  | string                | ISO-8601 text from PostgreSQL, stored as `Value::Bytes`. Use `parse_timestamp` in VRL to convert if needed. |
+				| `uuid`, `inet`, `cidr`, `macaddr`, `interval` and other typed columns | string  | Surface as their text representation (`Value::Bytes`); convert in VRL if you need typed values. |
+
+				Two type-handling rules drive this table:
+
+				- `numeric` columns are kept as strings so arbitrary-precision values are never silently
+				  rounded. If you need float arithmetic, do it explicitly in a VRL transform:
+				  `.new.amount = to_float!(.new.amount)`.
+				- `bytea` columns are passed through as raw bytes, not base64-encoded. The encoding
+				  decision belongs to the downstream sink (or a VRL `encode_base64` call), not this source.
+
+				### TOAST'd columns
+
+				When PostgreSQL elects not to re-send a TOAST'd value because it did not change in an
+				UPDATE, the source omits that column from the `new` (and `old`) payload entirely. The
+				omitted column names are reported in a metadata field `__toast_omitted` so downstream
+				consumers can distinguish "value was unchanged" from "value is missing":
+
+				```json
+				{
+				  "operation": "update",
+				  "new": { "id": 42, "status": "complete" },
+				  "old": { "id": 42 },
+				  "__toast_omitted": ["large_text_body"]
+				}
+				```
+
+				This avoids the common antipattern of injecting a sentinel string like
+				`"__toast_unchanged__"` into a column whose downstream schema may expect an integer or
+				bytea — which would cause coercion failures in strict sinks such as ClickHouse.
+				"""
+		}
+
+		generic_wal_messages: {
+			title: "Generic WAL messages (`pg_logical_emit_message`)"
+			body: """
+				PostgreSQL exposes a `pg_logical_emit_message(transactional bool, prefix text, content
+				text-or-bytea)` function for embedding application-level markers into the WAL stream. The
+				source surfaces these as `operation = "message"` events:
+
+				| Field                   | Description                                                                |
+				|-------------------------|----------------------------------------------------------------------------|
+				| `operation`             | Literal `"message"`                                                        |
+				| `lsn`                   | The message's WAL position (or the transaction's commit LSN if it is transactional) |
+				| `transactional`         | `true` if emitted inside a transaction, `false` otherwise                  |
+				| `prefix`                | The application-defined prefix                                              |
+				| `content`               | Raw bytes — binary-safe, including embedded NULs and non-UTF-8 sequences   |
+				| `transaction_id`        | The XID; absent for non-transactional messages                              |
+				| `transaction_timestamp` | Commit timestamp; absent for non-transactional messages                     |
+				| `new`, `old`, `schema`, `table` | Absent on `message` events — pattern-match on `operation == "message"` rather than checking for `null` |
+
+				Transactional messages share the enclosing transaction's commit LSN and acknowledge as
+				part of that transaction. Non-transactional messages carry their own LSN and acknowledge
+				independently — useful as lightweight heartbeats or stream checkpoints.
+				"""
+		}
+
+		reconnection: {
+			title: "Reconnection and resume semantics"
+			body: """
+				If the replication connection drops, Vector's topology will restart the source. On
+				restart the source attaches to the same slot and passes `0/0` to `START_REPLICATION`,
+				which causes PostgreSQL to resume from the slot's current `confirmed_flush_lsn`. No data
+				is lost. Because PostgreSQL provides at-least-once delivery, the very last acknowledged
+				transaction may be re-delivered after a restart; consumers should dedupe by `lsn` if
+				exactly-once semantics are required.
+
+				The relation cache is rebuilt from scratch on every reconnect — PostgreSQL re-sends
+				`Relation` messages before resuming row events, so this happens transparently.
+				"""
+		}
+
+		operational_tuning: {
+			title: "Operational tuning and PostgreSQL configuration"
+			body:  """
+				This source's behaviour is tightly coupled to how the PostgreSQL server is
+				configured. The most important relationships are summarised below; getting
+				any of them wrong typically surfaces as either (a) the WAL directory growing
+				until the database server runs out of disk, or (b) the source disconnecting
+				under load.
+
+				### 1. WAL retention and back-pressure (most critical)
+
+				With `acknowledgements: true` (the default), Vector advances the slot's
+				`confirmed_flush_lsn` only after every downstream sink has acknowledged the
+				events in a given transaction. PostgreSQL cannot recycle WAL segments newer
+				than the oldest active slot's `confirmed_flush_lsn`. The chain therefore is:
+
+				**slow sink → Vector stops acknowledging → slot stops advancing → PG retains WAL → `pg_wal/` grows until the disk fills**.
+
+				This is by design — it is what makes the source safe — but it means operators
+				must monitor it actively. Suggested guard-rails:
+
+				- Size sinks and Vector's buffers for your **peak** transaction volume, not the
+				  average. A bulk import that doubles your normal write rate for an hour is
+				  often where this fails.
+				- Set `max_replication_slots` and `max_wal_senders` to at least `1` per
+				  Vector instance attached to this database (more if you have other consumers).
+				- Monitor the slot lag: `pg_wal_lsn_diff(pg_current_wal_lsn(),
+				  confirmed_flush_lsn)` from `pg_replication_slots`. Alert when it exceeds a
+				  comfortable fraction of `max_wal_size`.
+				- Monitor `pg_replication_slots.active`. A slot that goes `inactive`
+				  unexpectedly means Vector disconnected and the WAL is now accumulating with
+				  no consumer.
+				- **Observability**: Use Vector's [`postgresql_metrics`](\(urls.vector_components)/sources/postgresql_metrics)
+				  source to automatically collect these metrics as `pg_replication_slots_confirmed_lag_bytes`
+				  and `pg_replication_slots_active`.
+
+				### 2. Transaction memory and spilling
+
+				PostgreSQL 13+ exposes `logical_decoding_work_mem` (default 64MB). When a
+				single transaction's decoded changes exceed this limit, PG spills them to
+				disk on the server side before streaming. Vector is largely unaffected — it
+				just receives the stream slightly later — but the server pays in I/O.
+
+				If you regularly run multi-GB transactions (bulk loads, schema migrations),
+				raise `logical_decoding_work_mem` to keep the spill on the server side
+				bounded. Note that this source uses pgoutput protocol version 1, which
+				holds the entire transaction in memory until COMMIT regardless; see the
+				[protocol version section](#pgoutput-protocol-version-and-large-transaction-handling).
+
+				### 3. Connection timeouts and heartbeats
+
+				PostgreSQL's `wal_sender_timeout` (default 60s) terminates the replication
+				connection if no client activity is observed for that long. pgwire-replication
+				handles standby-status keepalives on Vector's behalf, and Vector polls its
+				LSN tracker every 250ms, so this should never trigger in healthy operation.
+
+				If you see `terminating walsender process due to replication timeout` in the
+				PostgreSQL log:
+
+				1. Check Vector's CPU. A saturated source task can delay keepalive replies.
+				2. Check network latency between Vector and PG.
+				3. As a last resort, raise `wal_sender_timeout` on the database, but treat
+				   that as a workaround — the real fix is to address the underlying delay.
+
+				### 4. LSN advancement cadence
+
+				LSN advancement is **not** per-event — it is per-poll. Internally Vector polls
+				its LSN tracker every 250ms and, when the tracker reports new progress,
+				forwards an applied-LSN update to pgwire-replication; pgwire's own status
+				interval (500ms in this source) then sends a `StandbyStatusUpdate` to the
+				server. End-to-end, the slot's `confirmed_flush_lsn` updates within ~750ms
+				of the last sink acknowledgement, well under PostgreSQL's
+				`checkpoint_timeout` (default 5 minutes). There is virtually never a reason
+				to tune the internal interval; if you find yourself wanting to, file an issue
+				with the workload that motivated it.
+
+				### 5. Recommended PostgreSQL configuration for production
+
+				These settings together keep the WAL from running away while preserving
+				replay safety:
+
+				```
+				wal_level                  = logical        # required
+				max_replication_slots      = >= 1            # one per CDC consumer
+				max_wal_senders            = >= 1            # one per CDC consumer
+				max_wal_size               = sized for your retention window  # bounds disk pressure
+				wal_sender_timeout         = 60s             # default is fine in most setups
+				logical_decoding_work_mem  = 64MB or higher   # raise if you run big transactions
+				```
+
+				`wal_keep_size` (or `wal_keep_segments` on PG <13) provides a *floor* of
+				WAL retention — useful for non-slot consumers, but irrelevant here: an
+				active replication slot will retain WAL **indefinitely**, overriding this
+				setting, until the consumer either advances `confirmed_flush_lsn` or the
+				slot is dropped. Do not rely on `wal_keep_size` as a safety valve.
+
+				### 6. Tuning summary
+
+				| Goal               | PostgreSQL parameter      | Vector / pipeline lever            | Notes                                                                                                |
+				|--------------------|---------------------------|------------------------------------|------------------------------------------------------------------------------------------------------|
+				| Bound disk usage   | `max_wal_size`            | Sink throughput; `acknowledgements`| If sinks fall behind under acks, WAL grows. Size both for peak load.                                  |
+				| Source can start   | `wal_level = logical`     | `replication_slot`, `publication_name` | Both must be created out-of-band before the source starts.                                       |
+				| Big transactions   | `logical_decoding_work_mem` | (none — affects PG-side I/O)    | Raise on PG side to reduce spill-to-disk; Vector behaviour unchanged.                                |
+				| Connection stays up| `wal_sender_timeout`      | Vector CPU allocation              | Saturated source CPU can delay heartbeats; allocate enough first, then raise the timeout if needed.  |
+				| Resume after restart | `confirmed_flush_lsn`   | E2E ack pipeline                   | Source resumes from slot position; PG's at-least-once may re-deliver the last txn (dedupe by `lsn`). |
+				"""
+		}
+
+		protocol_version_and_streaming: {
+			title: "pgoutput protocol version and large-transaction handling"
+			body: """
+				This source uses pgoutput **protocol version 1**, which delivers each transaction
+				atomically *after* `COMMIT`. PostgreSQL 14 introduced protocol version 2, which adds
+				`StreamStart`/`StreamStop`/`StreamCommit`/`StreamAbort` messages so very large
+				transactions can be decoded incrementally on the server instead of being buffered in
+				shared memory until commit. The Rust client library this source builds on does not
+				currently implement v2, and adopting it is non-trivial because v2 mid-transaction
+				streaming interacts with Vector's end-to-end acknowledgement model:
+
+				- A row event delivered before its enclosing transaction commits can later be aborted
+				  on the server side. Once that event has been acknowledged downstream, Vector cannot
+				  un-write it from the sink.
+
+				- The two clean ways to reconcile this are (a) buffer the streamed rows on the Vector
+				  side and only release them on `StreamCommit`, which gives back the latency benefit
+				  but keeps ack semantics correct, or (b) propagate abort markers downstream and
+				  require every sink to be 2-phase-commit aware. Vector's current sink layer does not
+				  expose a 2PC contract, so (a) is the only safe path today.
+
+				### Practical impact
+
+				With protocol version 1 the entire transaction is held in PostgreSQL's
+				`logical_decoding_work_mem`. For very large transactions (think bulk imports producing
+				tens of millions of changes) this can cause server-side memory pressure or, in pre-PG
+				14 versions, slot disconnects. If you regularly run such transactions, consider:
+
+				- Chunking the work into smaller transactions.
+				- Increasing `logical_decoding_work_mem` on the server (PG 13+).
+				- Tracking the future `streaming_mode: "buffered_v2"` configuration option (planned),
+				  which will negotiate protocol version 2 and buffer the streamed rows on the Vector
+				  side, releasing them atomically on commit.
+				"""
+		}
+	}
+
+	output: {
+		logs: change_event: {
+			description: """
+				A single PostgreSQL change event. One LogEvent is emitted for each row affected by an
+				INSERT, UPDATE, DELETE, or TRUNCATE statement on a published table, plus one event for
+				each `pg_logical_emit_message` call.
+				"""
+			fields: {
+				operation: {
+					description: "The kind of change this event describes."
+					required:    true
+					type: string: {
+						enum: {
+							insert:   "A new row was inserted."
+							update:   "An existing row was modified."
+							delete:   "A row was deleted."
+							truncate: "The table was truncated."
+							message:  "A generic WAL message emitted by `pg_logical_emit_message`."
+						}
+					}
+				}
+				schema: {
+					description: "The PostgreSQL schema (namespace) of the affected table. Absent on `message` events."
+					required:    false
+					common:      true
+					type: string: {
+						default: null
+						examples: ["public", "billing"]
+					}
+				}
+				table: {
+					description: "The unqualified table name of the affected relation. Absent on `message` events."
+					required:    false
+					common:      true
+					type: string: {
+						default: null
+						examples: ["orders", "customers"]
+					}
+				}
+				lsn: {
+					description: """
+						The PostgreSQL Log Sequence Number associated with this event, in `X/Y` hex format.
+						For row events, this is the commit LSN of the enclosing transaction — every event in
+						one transaction shares one `lsn`. For non-transactional WAL messages, this is the
+						message's own LSN. LSNs are monotonically non-decreasing in delivery order.
+						"""
+					required: true
+					type: string: {
+						examples: ["16/B374D848", "0/1A2B3C4"]
+					}
+				}
+				transaction_id: {
+					description: "The PostgreSQL transaction id (xid) of the enclosing transaction. Absent on non-transactional `message` events."
+					required:    false
+					common:      true
+					type: uint: {
+						default: null
+						unit:    null
+						examples: [12345]
+					}
+				}
+				transaction_timestamp: fields._current_timestamp & {
+					description: "The commit timestamp of the enclosing transaction, in RFC 3339 format. Absent on non-transactional `message` events."
+				}
+				new: {
+					description: """
+						The new row image as an object keyed by column name. Populated for `insert` and
+						`update`. `null` for `delete` and `truncate`; absent on `message` events. Columns
+						omitted due to TOAST optimization are not present in this object — see the
+						`__toast_omitted` field.
+						"""
+					required: false
+					common:   true
+					type: object: examples: [{id: 42, status: "pending"}]
+				}
+				old: {
+					description: """
+						The old row image. Populated for `delete` (key columns only by default, full row if
+						`REPLICA IDENTITY FULL` is set) and for `update` when the table's replica identity
+						captures the previous row. `null` for `insert` and `truncate`; absent on `message`
+						events.
+						"""
+					required: false
+					common:   true
+					type: object: examples: [{id: 42, status: "pending"}]
+				}
+				operation_when_message: {
+					description: """
+						The following four fields are only present when `operation == "message"`.
+						"""
+					required: false
+					common:   false
+					type: object: {}
+				}
+				transactional: {
+					description: """
+						Whether this `message` event was emitted inside a transaction. Only present when
+						`operation == "message"`.
+						"""
+					required: false
+					common:   false
+					type: bool: default: null
+				}
+				prefix: {
+					description: "The application-defined prefix supplied to `pg_logical_emit_message`. Only present when `operation == \"message\"`."
+					required:    false
+					common:      false
+					type: string: {
+						default: null
+						examples: ["vector.heartbeat", "myapp.checkpoint"]
+					}
+				}
+				content: {
+					description: """
+						The raw bytes supplied to `pg_logical_emit_message`. Binary-safe — preserved
+						byte-for-byte including embedded null bytes and non-UTF-8 sequences. Only present
+						when `operation == "message"`.
+						"""
+					required: false
+					common:   false
+					type: string: {
+						default: null
+						examples: ["beat", "checkpoint=42"]
+					}
+				}
+				toast_omitted: {
+					description: """
+						The field name is `__toast_omitted` on the LogEvent. Contains the names of columns
+						that PostgreSQL did not re-send because their TOAST'd values did not change in this
+						UPDATE. Only present when at least one column is omitted.
+						"""
+					required: false
+					common:   false
+					type: array: {
+						default: null
+						items: type: string: examples: ["large_text_body"]
+					}
+				}
+			}
+		}
+	}
+
+	telemetry: metrics: {
+		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
+		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
+	}
+}

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -64,6 +64,7 @@ components: sources: postgresql_metrics: {
 				- `pg_stat_database`
 				- `pg_stat_database_conflicts`
 				- `pg_stat_bgwriter`
+				- `pg_replication_slots`
 				"""
 		}
 	}
@@ -88,10 +89,22 @@ components: sources: postgresql_metrics: {
 			}
 		}
 		_postgresql_metrics_tags_with_db: _postgresql_metrics_tags & {
-			type: {
+			db: {
 				description: "Database name."
 				required:    true
 				examples: ["postgres"]
+			}
+		}
+		_postgresql_replication_slot_tags: _postgresql_metrics_tags_with_db & {
+			slot_name: {
+				description: "The name of the replication slot."
+				required:    true
+				examples: ["vector_slot"]
+			}
+			wal_status: {
+				description: "The status of the WAL files for this slot (PG 13+)."
+				required:    false
+				examples: ["reserved", "extended", "lost"]
 			}
 		}
 
@@ -316,6 +329,24 @@ components: sources: postgresql_metrics: {
 			type:              "gauge"
 			default_namespace: "postgresql"
 			tags:              _postgresql_metrics_tags
+		}
+		pg_replication_slots_active: {
+			description:       "Whether the replication slot is currently active."
+			type:              "gauge"
+			default_namespace: "postgresql"
+			tags:              _postgresql_replication_slot_tags
+		}
+		pg_replication_slots_restart_lag_bytes: {
+			description:       "The amount of WAL data (in bytes) that must be retained for this slot since its `restart_lsn`. Not emitted when PostgreSQL returns NULL (for example, on a standby server where `pg_current_wal_lsn()` is unavailable, or when the slot has no `restart_lsn` yet)."
+			type:              "gauge"
+			default_namespace: "postgresql"
+			tags:              _postgresql_replication_slot_tags
+		}
+		pg_replication_slots_confirmed_lag_bytes: {
+			description:       "The amount of WAL data (in bytes) between the current WAL position and the slot's `confirmed_flush_lsn`. Not emitted when PostgreSQL returns NULL (for example, on a standby server, or when the slot has not yet confirmed any flush)."
+			type:              "gauge"
+			default_namespace: "postgresql"
+			tags:              _postgresql_replication_slot_tags
 		}
 	}
 }


### PR DESCRIPTION
#  `feat(new source): add postgresql_cdc source and replication slot metrics`

## Summary

Adds a new `postgresql_cdc` source for change-data-capture using logical replication and enhances the existing `postgresql_metrics` source with replication-slot health metrics so operators can monitor and alert on the back-pressure the CDC source can create.

The `postgresql_cdc` source:
- Streams INSERT / UPDATE / DELETE / TRUNCATE events via the `pgoutput` plugin.
- Captures `pg_logical_emit_message` events (transactional and non-transactional, binary-safe).
- Integrates with Vector's E2E acknowledgement system; `confirmed_flush_lsn` only advances after every event from a committed transaction has been acknowledged downstream.

The `postgresql_metrics` enhancement:
- Adds `pg_replication_slots_active`, `pg_replication_slots_confirmed_lag_bytes`, and `pg_replication_slots_restart_lag_bytes`.
- Exposes `wal_status` as a tag on PG 13+.
- Honours the same `include_databases` / `exclude_databases` filters as the existing per-database stats.
- Fills the observability gap identified during the CDC design: a standard way to alert on WAL lag caused by replication slots without needing an external exporter.

Closes / addresses [#20179](https://github.com/vectordotdev/vector/issues/20179) (CDC tool for databases).

## Why this fits Vector

Issue #20179 raised the legitimate concern that general-purpose CDC may sit outside Vector's observability-first scope. This implementation is positioned squarely inside that scope:

- **Database state as a first-class observability signal**: audit trails (who changed what, when), schema-evolution monitoring, drift detection between primary and replica systems, and feeding row-level changes into existing observability sinks (Loki, Elasticsearch, ClickHouse, Honeycomb).
- **Batteries-included telemetry**: shipping `postgresql_metrics` slot metrics alongside the CDC source gives operators a standard "operational safety" path — they can alert on a stuck slot before the WAL disk fills, without standing up `pg_exporter`.
- **No competition with full ETL tools**: we explicitly do not implement initial-snapshot mode, schema-registry integration, or backfill. Operators who need those use Debezium/Sequin and pipe to Vector. Operators already on Vector get a streaming-only CDC source that lives inside their existing pipeline.

## Technical highlights

- **End-to-end acknowledgement via a custom `LsnTracker`**: each transaction's events share one commit LSN; batch receivers are buffered per-transaction and only registered with the tracker on `Commit`, so `poll_confirmed()` never sees a partial set and cannot advance the LSN mid-transaction. The slot only advances when *every* event from that transaction has been acknowledged. Cross-references `vector_lib::finalizer::OrderedFinalizer` in the doc-comment explaining why a custom tracker is required (per-LSN `Vec`, contiguous-prefix advancement, monotonic `mark_delivered_immediately` for at-most-once mode).
- **`NUMERIC` precision is preserved exactly** by emitting as `Value::Bytes` rather than casting to `f64`. Documented and unit-tested with currency-style precision cases (`9999999999.9999`, `-0.0001`, 21-digit values beyond i64 and f64 mantissa). Users wanting float arithmetic do it explicitly in VRL.
- **`bytea` is byte-exact** — integration test feeds `\x00ffFEc0 + "hello"` through `pg_logical_emit_message(false, ..., bytea)` and asserts byte-for-byte preservation including embedded nulls and invalid UTF-8.
- **Version-aware slot metrics**: handles `pg_current_wal_lsn` vs `pg_current_xlog_location` (PG 10+ vs older), `wal_status` availability (PG 13+), and respects `include_databases` / `exclude_databases` filters via a shared SQL-builder path.
- **SQL-injection-safe identifier handling**: `replication_slot` and `publication_name` are validated against PG identifier rules at config-load time (the upstream `pgwire-replication` crate does not escape slot names in `START_REPLICATION`).
- **TLS-honouring setup connection**: validation queries against `pg_replication_slots` use the same TLS posture as the replication connection — no cleartext password leak.
- **Slot-state validation**: `validate_slot()` checks `plugin = 'pgoutput'`, `active = false`, and `wal_status != 'lost'` so misconfigurations surface as clear errors at startup rather than cryptic mid-stream failures.
- **Bounded `LsnTracker`**: the pending map is capped (100k entries); when reached the replication loop pauses pulling events from the wire, applying back-pressure to the upstream PG side rather than OOMing Vector.

## What's intentionally out of scope

- **`proto_version 2` streaming** of in-progress transactions. Requires either client-side buffering (defeats latency benefit) or 2PC-aware sinks (Vector's sink layer doesn't model rollback). Documented as a known limitation with a `buffered_v2` roadmap entry in the CUE doc. `pgwire-replication 0.3.2` hardcodes proto_v1; upstream issues to file.
- **Initial-snapshot mode**. The source attaches to an already-running slot; bootstrap (e.g., `pg_dump` + start) is an operator responsibility, deliberately.
- **Source-managed slot creation/deletion**. An abandoned slot can fill the WAL disk and take the database down — slot lifecycle stays with the DBA.

## Test coverage

- **34 unit tests** covering: LSN tracker invariants (Vec-per-LSN, contiguous prefix, Closed/Dropped/Errored semantics, monotonic mark-delivered-immediately, back-pressure cap signalling), pgoutput binary parser (Relation/Insert/Update/Delete/Truncate, TOAST omission, schema change, table-driven `decode_value` across 14 OIDs with currency-precision cases), connection-string parsing, identifier validation against SQL injection.
- **32 integration tests** against a real Postgres 16 in Docker:
  - **24 in `postgresql_cdc`**: insert / update / delete / truncate, multi-table publication, LSN advancement after ack, large-transaction shared LSN, reconnect resume, dropped events advance slot, numeric preservation, schema change mid-stream, mixed DML in one transaction, sustained slot advancement, resume-does-not-replay-history (strict assertion: max 4 events on resume), transactional + non-transactional + binary WAL messages, transaction rollback emits no events, concurrent writers preserve LSN ordering, dropped table mid-stream, REPLICA IDENTITY NOTHING + USING INDEX coverage, source-compliance metric emission.
  - **8 in `postgresql_metrics`** (the ones runnable against the CDC integration env): `test_host`, the four include/exclude-database filter tests, and the new `test_replication_slots` for the slot lag metrics.
- The 2 `postgresql_metrics` tests `test_local` and `test_host_ssl` require Unix-socket and SSL-cert infrastructure available only in the existing `postgres` integration env; they continue to pass there and are unaffected by this PR's changes.
- **3 consecutive full-suite runs against this PR's container: 66/66 passing, zero flakes.**
- **Peer review findings addressed**: TLS bypass on setup connection, parse-error halt vs silent advance, SQL injection in slot name, ack-disabled WAL growth, lossy password UTF-8, LsnTracker memory cap, ack-`Closed` semantics matching kafka, alloc-free `poll_confirmed`, error-context preservation, `wal_status`/`active` validation, password-in-Debug risk note, mid-transaction LSN advancement race.

## Internal events / metrics (per CONTRIBUTING.md)

Standard `ComponentReceivedBytesTotal` / `ComponentReceivedEventsTotal` / `ComponentReceivedEventBytesTotal` emitted via the canonical `BytesReceived` / `EventsReceived` registered events (verified by an `assert_source_compliance` integration test). Source-specific error events emit `ComponentErrorsTotal` with `error_code` discriminators: `pgoutput_parse`, `replication_stream`, `sink_ack_failed`, `protocol_violation`.

## Test plan

- [x] `cargo build --features sources-postgresql_cdc,sources-postgresql_metrics` clean
- [x] `cargo clippy --features sources-postgresql_cdc,sources-postgresql_metrics --tests` clean
- [x] `cargo nextest run --features sources-postgresql_cdc` (unit) — 34/34 pass
- [x] `cargo nextest run --features postgresql_cdc-integration-tests` against Docker PG16 — 24/24 pass
- [x] `cargo nextest run --features postgresql_metrics-integration-tests` against the CDC compose — 8/8 pass (including the new `test_replication_slots`); the SSL + Unix-socket tests run against the existing `postgres` integration env as before
- [x] 3× consecutive full-suite runs against the CDC compose — 66/66 each, zero flakes
- [x] `cargo vdev check docs` — only the pre-existing unrelated remap-errors issue
- [x] Source appears in `vector list`
- [x] Example config: `config/examples/postgresql_cdc.yaml`
- [x] CUE docs: `website/cue/reference/components/sources/{postgresql_cdc,postgresql_metrics}.cue` with output schema, data-type-mapping table, generic-WAL-message handling, proto-version limitation, minimum PG privilege examples, operational tuning section (WAL retention, transaction memory, heartbeats, LSN cadence, recommended PG config), slot-metric documentation
- [x] Changelog fragment: `changelog.d/postgresql_cdc_source.feature.md`
- [x] CI workflow registration: `.github/workflows/{integration.yml,changes.yml,ci-integration-review.yml}`

## Future work (separately tracked)

- `streaming_mode: "buffered_v2"` config option that negotiates pgoutput proto_v2 and buffers in-progress transactions client-side
- Upstream patches to `pgwire-replication`: redact password in `Debug`, quote slot identifier in `START_REPLICATION`, expose proto_v2 streaming
- Relation-cache LRU bound (defence against malicious server)
- `LsnTracker` lag gauge (`postgresql_cdc_pending_lsns` for monitoring backpressure)
- PostGIS / composite-type integration test (requires container swap to `postgis/postgis:16-3.x`)
